### PR TITLE
Phase 2 — auth + MCP discovery checks (webBotAuth, oauthDiscovery, oauthProtectedResource, apiCatalog, mcpServerCard)

### DIFF
--- a/lib/engine/checks/_shared.ts
+++ b/lib/engine/checks/_shared.ts
@@ -1,10 +1,12 @@
 /**
- * Internal helpers shared by the robots.txt-dependent checks that live in
- * this directory (robotsTxtAiRules, contentSignals). Not part of the public
- * engine API — intentionally prefixed with `_` to signal that.
+ * Cross-check shared helpers: JSON parsing, robots fetch-failure plumbing,
+ * AI bot token list.
  *
- * If more checks elsewhere in the codebase later need to depend on robots.txt
- * fetch-failure plumbing, promote this module up one level.
+ * Not part of the public engine API — intentionally prefixed with `_` to
+ * signal that. `tryParseJson` is consumed by the Phase-2 JSON-probing checks
+ * (api-catalog, oauth-discovery, oauth-protected-resource, mcp-server-card),
+ * while `buildFailNoRobots` and `AI_BOT_TOKENS` are consumed by the
+ * robots.txt-dependent checks (robotsTxtAiRules, contentSignals).
  */
 
 import {

--- a/lib/engine/checks/_shared.ts
+++ b/lib/engine/checks/_shared.ts
@@ -15,6 +15,20 @@ import {
 import type { CheckResult, EvidenceStep } from "@/lib/schema";
 
 /**
+ * Best-effort JSON parse — returns `undefined` on empty input or parse error.
+ * Lifted here from the per-check duplicates so every JSON-probing check
+ * shares a single implementation.
+ */
+export function tryParseJson(body: string | undefined): unknown | undefined {
+  if (body === undefined || body.length === 0) return undefined;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Canonical (lowercase) list of AI crawler user-agent tokens probed for in
  * robots.txt User-agent lines. Exported so sibling checks can reuse the same
  * set without redeclaring it. Frozen `as const` to make the intent

--- a/lib/engine/checks/api-catalog.ts
+++ b/lib/engine/checks/api-catalog.ts
@@ -8,6 +8,14 @@
  * - Pass criterion: 200 response + `application/linkset+json` content type
  *   + non-empty `linkset[]` array in the body.
  *
+ * Divergence from the full RFC 9727 flow
+ * --------------------------------------
+ * RFC 9727 also allows advertising the catalog via a homepage `Link` header
+ * (`rel="api-catalog"`) or a `/llms.txt` reference. The current oracle
+ * fixtures only exercise the well-known probe, so this check intentionally
+ * implements only that path. Expanding to Link-header / llms.txt probing is
+ * deferred until we have real pass fixtures to ground-truth against.
+ *
  * Evidence timeline
  * -----------------
  * Fail path (all 5 oracle fixtures): `fetch → conclude`.
@@ -20,6 +28,7 @@ import {
   makeStep,
   type ScanContext,
 } from "@/lib/engine/context";
+import { tryParseJson } from "./_shared";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -38,15 +47,6 @@ const FAIL_MESSAGE = "API Catalog not found";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function tryParseJson(body: string | undefined): unknown | undefined {
-  if (body === undefined || body.length === 0) return undefined;
-  try {
-    return JSON.parse(body);
-  } catch {
-    return undefined;
-  }
-}
 
 function isLinksetJson(contentType: string | undefined): boolean {
   if (contentType === undefined) return false;

--- a/lib/engine/checks/api-catalog.ts
+++ b/lib/engine/checks/api-catalog.ts
@@ -1,0 +1,190 @@
+/**
+ * Discovery check: `apiCatalog` (RFC 9727).
+ *
+ * Specification (FINDINGS §3 / §9)
+ * --------------------------------
+ * - Probe `GET /.well-known/api-catalog` with
+ *   `Accept: application/linkset+json, application/json`.
+ * - Pass criterion: 200 response + `application/linkset+json` content type
+ *   + non-empty `linkset[]` array in the body.
+ *
+ * Evidence timeline
+ * -----------------
+ * Fail path (all 5 oracle fixtures): `fetch → conclude`.
+ * Pass path: `fetch → validate → conclude`.
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type ScanContext,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROBE_PATH = "/.well-known/api-catalog";
+const FETCH_LABEL = "GET /.well-known/api-catalog";
+const VALIDATE_LABEL = "Validate linkset structure";
+const CONCLUDE_LABEL = "Conclusion";
+
+const ACCEPT_HEADER = "application/linkset+json, application/json";
+
+const PASS_MESSAGE = "API Catalog found";
+const FAIL_MESSAGE = "API Catalog not found";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tryParseJson(body: string | undefined): unknown | undefined {
+  if (body === undefined || body.length === 0) return undefined;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function isLinksetJson(contentType: string | undefined): boolean {
+  if (contentType === undefined) return false;
+  return contentType.toLowerCase().includes("application/linkset+json");
+}
+
+function extractLinkset(json: unknown): unknown[] | undefined {
+  if (json === null || typeof json !== "object") return undefined;
+  const linkset = (json as { linkset?: unknown }).linkset;
+  if (!Array.isArray(linkset)) return undefined;
+  return linkset;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkApiCatalog(ctx: ScanContext): Promise<CheckResult> {
+  const started = Date.now();
+  const outcome = await ctx.fetch(PROBE_PATH, {
+    headers: { Accept: ACCEPT_HEADER },
+  });
+
+  const evidence: EvidenceStep[] = [];
+
+  // Transport error.
+  if (outcome.response === undefined) {
+    evidence.push(
+      fetchToStep(outcome, FETCH_LABEL, {
+        outcome: "negative",
+        summary: `Transport error fetching API Catalog: ${outcome.error ?? "no response"}`,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  const { response } = outcome;
+
+  // Non-200.
+  if (response.status !== 200) {
+    evidence.push(
+      fetchToStep(outcome, FETCH_LABEL, {
+        outcome: "negative",
+        summary: `Server returned ${response.status} -- API Catalog not found`,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  // 200 — check content-type + linkset body.
+  const contentType = response.headers["content-type"];
+  const json = tryParseJson(outcome.body);
+  const linkset = extractLinkset(json);
+
+  if (
+    !isLinksetJson(contentType) ||
+    linkset === undefined ||
+    linkset.length === 0
+  ) {
+    const reason =
+      linkset === undefined
+        ? "Response body is not a linkset JSON document"
+        : linkset.length === 0
+          ? "Linkset is empty"
+          : `Unexpected content-type ${contentType ?? "(none)"} -- expected application/linkset+json`;
+    evidence.push(
+      fetchToStep(outcome, FETCH_LABEL, {
+        outcome: "negative",
+        summary: `Received 200 but ${reason.toLowerCase()}`,
+      }),
+    );
+    evidence.push(
+      makeStep("validate", VALIDATE_LABEL, {
+        outcome: "negative",
+        summary: reason,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  // Pass.
+  evidence.push(
+    fetchToStep(outcome, FETCH_LABEL, {
+      outcome: "positive",
+      summary: "Received 200 with linkset+json body",
+    }),
+  );
+  evidence.push(
+    makeStep("validate", VALIDATE_LABEL, {
+      outcome: "positive",
+      summary: `Linkset contains ${linkset.length} entry(ies)`,
+    }),
+  );
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "positive",
+      summary: PASS_MESSAGE,
+    }),
+  );
+
+  return {
+    status: "pass",
+    message: PASS_MESSAGE,
+    details: { linksetSize: linkset.length },
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}

--- a/lib/engine/checks/api-catalog.ts
+++ b/lib/engine/checks/api-catalog.ts
@@ -128,12 +128,15 @@ export async function checkApiCatalog(ctx: ScanContext): Promise<CheckResult> {
     linkset === undefined ||
     linkset.length === 0
   ) {
-    const reason =
-      linkset === undefined
+    // Failure-reason ladder: check content-type first, then body shape. This
+    // keeps the message precise when both are wrong (a JSON body with the
+    // wrong content-type is reported as a content-type mismatch, not as
+    // "not a linkset JSON document").
+    const reason = !isLinksetJson(contentType)
+      ? `Unexpected content-type ${contentType ?? "(none)"} -- expected application/linkset+json`
+      : linkset === undefined
         ? "Response body is not a linkset JSON document"
-        : linkset.length === 0
-          ? "Linkset is empty"
-          : `Unexpected content-type ${contentType ?? "(none)"} -- expected application/linkset+json`;
+        : "Linkset is empty";
     evidence.push(
       fetchToStep(outcome, FETCH_LABEL, {
         outcome: "negative",

--- a/lib/engine/checks/mcp-server-card.ts
+++ b/lib/engine/checks/mcp-server-card.ts
@@ -1,0 +1,240 @@
+/**
+ * Discovery check: `mcpServerCard` (SEP-1649 / MCP PR #2127).
+ *
+ * Specification (FINDINGS §3 / §9)
+ * --------------------------------
+ * Probe three candidate paths concurrently:
+ *   - `/.well-known/mcp/server-card.json` (primary)
+ *   - `/.well-known/mcp/server-cards.json`
+ *   - `/.well-known/mcp.json`
+ *
+ * Pass criterion: any candidate returns 200 JSON identifying an MCP server.
+ * Two identifying shapes are accepted:
+ *   1. `{ name, version, endpoint }` (server-card primary shape)
+ *   2. `{ serverInfo: { name, version }, endpoint }` (alternative shape)
+ *
+ * Evidence timeline
+ * -----------------
+ * Three fetches (in concurrent resolution order) + conclusion. When a
+ * candidate responds with a valid card, an additional `validate` step is
+ * emitted before the conclusion.
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type FetchOutcome,
+  type ScanContext,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+interface Candidate {
+  readonly path: string;
+  readonly label: string;
+}
+
+const CANDIDATES: readonly Candidate[] = [
+  {
+    path: "/.well-known/mcp/server-card.json",
+    label: "GET /.well-known/mcp/server-card.json",
+  },
+  {
+    path: "/.well-known/mcp/server-cards.json",
+    label: "GET /.well-known/mcp/server-cards.json",
+  },
+  {
+    path: "/.well-known/mcp.json",
+    label: "GET /.well-known/mcp.json",
+  },
+];
+
+const CONCLUDE_LABEL = "Conclusion";
+const VALIDATE_LABEL = "Validate MCP server card";
+
+const PASS_MESSAGE = "MCP Server Card found";
+const FAIL_MESSAGE = "MCP Server Card not found";
+const FAIL_CONCLUDE_SUMMARY = "MCP Server Card not found at any candidate path";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tryParseJson(body: string | undefined): unknown | undefined {
+  if (body === undefined || body.length === 0) return undefined;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+interface ValidCard {
+  readonly name: string;
+  readonly version: string;
+  readonly endpoint: string;
+}
+
+function validateServerCard(json: unknown): ValidCard | undefined {
+  if (json === null || typeof json !== "object") return undefined;
+  const obj = json as Record<string, unknown>;
+
+  // Shape 1: { name, version, endpoint }
+  if (
+    typeof obj.name === "string" &&
+    typeof obj.version === "string" &&
+    typeof obj.endpoint === "string"
+  ) {
+    return {
+      name: obj.name,
+      version: obj.version,
+      endpoint: obj.endpoint,
+    };
+  }
+
+  // Shape 2: { serverInfo: { name, version }, endpoint }
+  const info = obj.serverInfo;
+  if (
+    info !== null &&
+    typeof info === "object" &&
+    typeof (info as Record<string, unknown>).name === "string" &&
+    typeof (info as Record<string, unknown>).version === "string" &&
+    typeof obj.endpoint === "string"
+  ) {
+    const si = info as Record<string, unknown>;
+    return {
+      name: si.name as string,
+      version: si.version as string,
+      endpoint: obj.endpoint,
+    };
+  }
+
+  return undefined;
+}
+
+interface ProbeResult {
+  readonly candidate: Candidate;
+  readonly outcome: FetchOutcome;
+  readonly fetchFinding: { outcome: "positive" | "negative"; summary: string };
+  readonly card?: ValidCard;
+}
+
+async function probe(
+  ctx: ScanContext,
+  candidate: Candidate,
+): Promise<ProbeResult> {
+  const outcome = await ctx.fetch(candidate.path);
+
+  if (outcome.response === undefined) {
+    return {
+      candidate,
+      outcome,
+      fetchFinding: {
+        outcome: "negative",
+        summary: `${candidate.path} request failed: ${outcome.error ?? "no response"}`,
+      },
+    };
+  }
+
+  if (outcome.response.status !== 200) {
+    return {
+      candidate,
+      outcome,
+      fetchFinding: {
+        outcome: "negative",
+        summary: `${candidate.path} returned ${outcome.response.status}`,
+      },
+    };
+  }
+
+  const json = tryParseJson(outcome.body);
+  const card = validateServerCard(json);
+  if (card === undefined) {
+    return {
+      candidate,
+      outcome,
+      fetchFinding: {
+        outcome: "negative",
+        summary: `${candidate.path} returned 200 but did not match MCP server card schema`,
+      },
+    };
+  }
+
+  return {
+    candidate,
+    outcome,
+    fetchFinding: {
+      outcome: "positive",
+      summary: `${candidate.path} returned a valid MCP server card`,
+    },
+    card,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkMcpServerCard(
+  ctx: ScanContext,
+): Promise<CheckResult> {
+  const started = Date.now();
+
+  const probes = CANDIDATES.map((c) => probe(ctx, c));
+  const results: ProbeResult[] = [];
+  await Promise.all(
+    probes.map(async (p) => {
+      results.push(await p);
+    }),
+  );
+
+  const evidence: EvidenceStep[] = [];
+  for (const r of results) {
+    evidence.push(fetchToStep(r.outcome, r.candidate.label, r.fetchFinding));
+  }
+
+  const found = results.find((r) => r.card !== undefined);
+  if (found?.card !== undefined) {
+    const { card } = found;
+    evidence.push(
+      makeStep("validate", VALIDATE_LABEL, {
+        outcome: "positive",
+        summary: `Valid card: name="${card.name}" version="${card.version}"`,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "positive",
+        summary: PASS_MESSAGE,
+      }),
+    );
+    return {
+      status: "pass",
+      message: PASS_MESSAGE,
+      details: {
+        source: found.candidate.path,
+        name: card.name,
+        version: card.version,
+        endpoint: card.endpoint,
+      },
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "negative",
+      summary: FAIL_CONCLUDE_SUMMARY,
+    }),
+  );
+  return {
+    status: "fail",
+    message: FAIL_MESSAGE,
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}

--- a/lib/engine/checks/mcp-server-card.ts
+++ b/lib/engine/checks/mcp-server-card.ts
@@ -15,9 +15,13 @@
  *
  * Evidence timeline
  * -----------------
- * Three fetches (in concurrent resolution order) + conclusion. When a
- * candidate responds with a valid card, an additional `validate` step is
- * emitted before the conclusion.
+ * Three fetches (emitted in fixed dispatch order — CANDIDATES index — not
+ * resolution order) + conclusion. When a candidate responds with a valid card,
+ * an additional `validate` step is emitted before the conclusion.
+ *
+ * Step budget:
+ *   - Pass path: 5 steps  (3 × fetch + validate + conclude)
+ *   - Fail path: 4 steps  (3 × fetch + conclude)
  */
 
 import type { CheckResult, EvidenceStep } from "@/lib/schema";
@@ -27,6 +31,7 @@ import {
   type FetchOutcome,
   type ScanContext,
 } from "@/lib/engine/context";
+import { tryParseJson } from "./_shared";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -63,15 +68,6 @@ const FAIL_CONCLUDE_SUMMARY = "MCP Server Card not found at any candidate path";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function tryParseJson(body: string | undefined): unknown | undefined {
-  if (body === undefined || body.length === 0) return undefined;
-  try {
-    return JSON.parse(body);
-  } catch {
-    return undefined;
-  }
-}
-
 interface ValidCard {
   readonly name: string;
   readonly version: string;
@@ -97,19 +93,17 @@ function validateServerCard(json: unknown): ValidCard | undefined {
 
   // Shape 2: { serverInfo: { name, version }, endpoint }
   const info = obj.serverInfo;
+  if (info === null || typeof info !== "object") return undefined;
+  const si = info as Record<string, unknown>;
+  const siName = si.name;
+  const siVersion = si.version;
+  const endpoint = obj.endpoint;
   if (
-    info !== null &&
-    typeof info === "object" &&
-    typeof (info as Record<string, unknown>).name === "string" &&
-    typeof (info as Record<string, unknown>).version === "string" &&
-    typeof obj.endpoint === "string"
+    typeof siName === "string" &&
+    typeof siVersion === "string" &&
+    typeof endpoint === "string"
   ) {
-    const si = info as Record<string, unknown>;
-    return {
-      name: si.name as string,
-      version: si.version as string,
-      endpoint: obj.endpoint,
-    };
+    return { name: siName, version: siVersion, endpoint };
   }
 
   return undefined;
@@ -183,12 +177,10 @@ export async function checkMcpServerCard(
 ): Promise<CheckResult> {
   const started = Date.now();
 
-  const probes = CANDIDATES.map((c) => probe(ctx, c));
-  const results: ProbeResult[] = [];
-  await Promise.all(
-    probes.map(async (p) => {
-      results.push(await p);
-    }),
+  // Dispatch-order-deterministic emission: results land at the same index
+  // as their candidate in CANDIDATES, regardless of which probe resolves first.
+  const results: readonly ProbeResult[] = await Promise.all(
+    CANDIDATES.map((c) => probe(ctx, c)),
   );
 
   const evidence: EvidenceStep[] = [];

--- a/lib/engine/checks/oauth-discovery.ts
+++ b/lib/engine/checks/oauth-discovery.ts
@@ -14,9 +14,13 @@
  * Evidence timeline
  * -----------------
  * For each endpoint: `fetch` step; if 200 JSON, a `validate` step also.
- * Terminal step is always a single `conclude`. Concurrent probes mean
- * ordering is non-deterministic — we emit the two probes' steps in the order
- * their fetch promises resolve, then append the conclusion.
+ * Terminal step is always a single `conclude`. Concurrent probes emit their
+ * evidence in fixed dispatch order (ENDPOINTS index), not resolution order —
+ * the result is deterministic for any caller that iterates evidence.
+ *
+ * Step budget:
+ *   - Pass (OIDC): up to 5 steps  (2 × fetch + 2 × validate + conclude)
+ *   - Fail:        3 steps        (2 × fetch + conclude)
  */
 
 import type { CheckResult, EvidenceStep } from "@/lib/schema";
@@ -26,6 +30,7 @@ import {
   type FetchOutcome,
   type ScanContext,
 } from "@/lib/engine/context";
+import { tryParseJson } from "./_shared";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -67,15 +72,6 @@ const FAIL_CONCLUDE_SUMMARY =
 // Helpers
 // ---------------------------------------------------------------------------
 
-function tryParseJson(body: string | undefined): unknown | undefined {
-  if (body === undefined || body.length === 0) return undefined;
-  try {
-    return JSON.parse(body);
-  } catch {
-    return undefined;
-  }
-}
-
 interface ValidatedMetadata {
   readonly issuer: string;
   readonly hasAuthorizationEndpoint: boolean;
@@ -94,7 +90,7 @@ function validateMetadata(json: unknown): ValidatedMetadata | undefined {
       : undefined;
   if (issuer === undefined || authz === undefined) return undefined;
   const grantTypes = Array.isArray(obj.grant_types_supported)
-    ? (obj.grant_types_supported.filter((v) => typeof v === "string") as string[])
+    ? obj.grant_types_supported.filter((v): v is string => typeof v === "string")
     : undefined;
   return {
     issuer,
@@ -196,17 +192,11 @@ export async function checkOauthDiscovery(
 ): Promise<CheckResult> {
   const started = Date.now();
 
-  // Probe both endpoints concurrently; emit evidence in resolution order.
-  const probes: Promise<ProbeResult>[] = ENDPOINTS.map((e) => probe(ctx, e));
-  const results: ProbeResult[] = [];
-  // We emit in resolution order using Promise.allSettled then sorting by start
-  // index would lose the concurrent ordering behaviour. Instead race each to
-  // completion in any order via a small helper:
-  await Promise.all(
-    probes.map(async (p) => {
-      const r = await p;
-      results.push(r);
-    }),
+  // Probe both endpoints concurrently; emit evidence in fixed dispatch order
+  // (ENDPOINTS index) so evidence is deterministic regardless of which probe
+  // resolves first.
+  const results: readonly ProbeResult[] = await Promise.all(
+    ENDPOINTS.map((e) => probe(ctx, e)),
   );
 
   const evidence: EvidenceStep[] = [];

--- a/lib/engine/checks/oauth-discovery.ts
+++ b/lib/engine/checks/oauth-discovery.ts
@@ -1,0 +1,273 @@
+/**
+ * Discovery check: `oauthDiscovery`.
+ *
+ * Specification (FINDINGS §3 / §9)
+ * --------------------------------
+ * Probe both well-known OAuth/OIDC metadata endpoints concurrently:
+ *   - `/.well-known/oauth-authorization-server` (RFC 8414)
+ *   - `/.well-known/openid-configuration`       (OIDC Discovery 1.0)
+ *
+ * Pass criterion: either endpoint returns 200 JSON with `issuer` and
+ * `authorization_endpoint` fields. We additionally record `token_endpoint`
+ * and `jwks_uri` presence in `details` to match the oracle shape.
+ *
+ * Evidence timeline
+ * -----------------
+ * For each endpoint: `fetch` step; if 200 JSON, a `validate` step also.
+ * Terminal step is always a single `conclude`. Concurrent probes mean
+ * ordering is non-deterministic — we emit the two probes' steps in the order
+ * their fetch promises resolve, then append the conclusion.
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type FetchOutcome,
+  type ScanContext,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+interface EndpointSpec {
+  readonly slug: "oauth-authorization-server" | "openid-configuration";
+  readonly path: string;
+  readonly fetchLabel: string;
+  readonly validateLabel: string;
+  readonly sourceName: string;
+}
+
+const ENDPOINTS: readonly EndpointSpec[] = [
+  {
+    slug: "oauth-authorization-server",
+    path: "/.well-known/oauth-authorization-server",
+    fetchLabel: "GET /.well-known/oauth-authorization-server",
+    validateLabel: "Validate oauth-authorization-server structure",
+    sourceName: "oauth-authorization-server",
+  },
+  {
+    slug: "openid-configuration",
+    path: "/.well-known/openid-configuration",
+    fetchLabel: "GET /.well-known/openid-configuration",
+    validateLabel: "Validate openid-configuration structure",
+    sourceName: "openid-configuration",
+  },
+];
+
+const CONCLUDE_LABEL = "Conclusion";
+const PASS_MESSAGE_OIDC = "OpenID Connect discovery metadata found";
+const PASS_MESSAGE_OAUTH = "OAuth authorization server metadata found";
+const FAIL_MESSAGE = "No OAuth/OIDC discovery metadata found";
+const FAIL_CONCLUDE_SUMMARY =
+  "No OAuth/OIDC discovery metadata found at either well-known path";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tryParseJson(body: string | undefined): unknown | undefined {
+  if (body === undefined || body.length === 0) return undefined;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+interface ValidatedMetadata {
+  readonly issuer: string;
+  readonly hasAuthorizationEndpoint: boolean;
+  readonly hasTokenEndpoint: boolean;
+  readonly hasJwksUri: boolean;
+  readonly grantTypes?: readonly string[];
+}
+
+function validateMetadata(json: unknown): ValidatedMetadata | undefined {
+  if (json === null || typeof json !== "object") return undefined;
+  const obj = json as Record<string, unknown>;
+  const issuer = typeof obj.issuer === "string" ? obj.issuer : undefined;
+  const authz =
+    typeof obj.authorization_endpoint === "string"
+      ? obj.authorization_endpoint
+      : undefined;
+  if (issuer === undefined || authz === undefined) return undefined;
+  const grantTypes = Array.isArray(obj.grant_types_supported)
+    ? (obj.grant_types_supported.filter((v) => typeof v === "string") as string[])
+    : undefined;
+  return {
+    issuer,
+    hasAuthorizationEndpoint: true,
+    hasTokenEndpoint: typeof obj.token_endpoint === "string",
+    hasJwksUri: typeof obj.jwks_uri === "string",
+    ...(grantTypes !== undefined ? { grantTypes } : {}),
+  };
+}
+
+interface ProbeResult {
+  readonly endpoint: EndpointSpec;
+  readonly outcome: FetchOutcome;
+  readonly metadata?: ValidatedMetadata;
+  readonly fetchFinding: { outcome: "positive" | "negative"; summary: string };
+  readonly validateFinding?: {
+    outcome: "positive" | "negative";
+    summary: string;
+  };
+}
+
+async function probe(
+  ctx: ScanContext,
+  endpoint: EndpointSpec,
+): Promise<ProbeResult> {
+  const outcome = await ctx.fetch(endpoint.path);
+
+  if (outcome.response === undefined) {
+    return {
+      endpoint,
+      outcome,
+      fetchFinding: {
+        outcome: "negative",
+        summary: `${endpoint.slug} request failed: ${outcome.error ?? "no response"}`,
+      },
+    };
+  }
+
+  if (outcome.response.status !== 200) {
+    return {
+      endpoint,
+      outcome,
+      fetchFinding: {
+        outcome: "negative",
+        summary: `${endpoint.slug} returned ${outcome.response.status}`,
+      },
+    };
+  }
+
+  const json = tryParseJson(outcome.body);
+  if (json === undefined) {
+    return {
+      endpoint,
+      outcome,
+      fetchFinding: {
+        outcome: "negative",
+        summary: `${endpoint.slug} returned 200 but body was not valid JSON`,
+      },
+    };
+  }
+
+  const metadata = validateMetadata(json);
+  if (metadata === undefined) {
+    return {
+      endpoint,
+      outcome,
+      fetchFinding: {
+        outcome: "negative",
+        summary: `${endpoint.slug} JSON missing required issuer/authorization_endpoint`,
+      },
+      validateFinding: {
+        outcome: "negative",
+        summary: "Missing required issuer/authorization_endpoint",
+      },
+    };
+  }
+
+  return {
+    endpoint,
+    outcome,
+    metadata,
+    fetchFinding: {
+      outcome: "positive",
+      summary: `Received JSON from ${endpoint.slug}`,
+    },
+    validateFinding: {
+      outcome: "positive",
+      summary: `Valid metadata with issuer: ${metadata.issuer}`,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkOauthDiscovery(
+  ctx: ScanContext,
+): Promise<CheckResult> {
+  const started = Date.now();
+
+  // Probe both endpoints concurrently; emit evidence in resolution order.
+  const probes: Promise<ProbeResult>[] = ENDPOINTS.map((e) => probe(ctx, e));
+  const results: ProbeResult[] = [];
+  // We emit in resolution order using Promise.allSettled then sorting by start
+  // index would lose the concurrent ordering behaviour. Instead race each to
+  // completion in any order via a small helper:
+  await Promise.all(
+    probes.map(async (p) => {
+      const r = await p;
+      results.push(r);
+    }),
+  );
+
+  const evidence: EvidenceStep[] = [];
+  for (const r of results) {
+    evidence.push(
+      fetchToStep(r.outcome, r.endpoint.fetchLabel, r.fetchFinding),
+    );
+    if (r.validateFinding !== undefined) {
+      evidence.push(
+        makeStep("validate", r.endpoint.validateLabel, r.validateFinding),
+      );
+    }
+  }
+
+  // Prefer the OIDC result when both pass (matches vercel oracle message).
+  const passing = results.find((r) => r.metadata !== undefined);
+  const oidcPass = results.find(
+    (r) => r.metadata !== undefined && r.endpoint.slug === "openid-configuration",
+  );
+  const chosen = oidcPass ?? passing;
+
+  if (chosen !== undefined && chosen.metadata !== undefined) {
+    const message =
+      chosen.endpoint.slug === "openid-configuration"
+        ? PASS_MESSAGE_OIDC
+        : PASS_MESSAGE_OAUTH;
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "positive",
+        summary: message,
+      }),
+    );
+    return {
+      status: "pass",
+      message,
+      details: {
+        source: chosen.endpoint.sourceName,
+        issuer: chosen.metadata.issuer,
+        hasAuthorizationEndpoint: chosen.metadata.hasAuthorizationEndpoint,
+        hasTokenEndpoint: chosen.metadata.hasTokenEndpoint,
+        hasJwksUri: chosen.metadata.hasJwksUri,
+        ...(chosen.metadata.grantTypes !== undefined
+          ? { grantTypes: chosen.metadata.grantTypes }
+          : {}),
+      },
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "negative",
+      summary: FAIL_CONCLUDE_SUMMARY,
+    }),
+  );
+
+  return {
+    status: "fail",
+    message: FAIL_MESSAGE,
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}

--- a/lib/engine/checks/oauth-protected-resource.ts
+++ b/lib/engine/checks/oauth-protected-resource.ts
@@ -1,0 +1,227 @@
+/**
+ * Discovery check: `oauthProtectedResource` (RFC 9728).
+ *
+ * Specification (FINDINGS §3 / §9)
+ * --------------------------------
+ * - Probe homepage (`GET /`) to look for a `WWW-Authenticate` header
+ *   advertising an OAuth resource server.
+ * - Probe `/.well-known/oauth-protected-resource` for the canonical metadata.
+ * - Pass criterion: well-known returns 200 JSON with a `resource` field.
+ *
+ * Evidence timeline
+ * -----------------
+ * Three steps: homepage fetch, well-known fetch, conclusion. The two fetches
+ * run concurrently; emission order follows resolution order (oracle fixtures
+ * show both orderings).
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type FetchOutcome,
+  type ScanContext,
+  type FetchRequestRecord,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WELL_KNOWN_PATH = "/.well-known/oauth-protected-resource";
+const HOMEPAGE_FETCH_LABEL = "GET /";
+const WELL_KNOWN_FETCH_LABEL = "GET /.well-known/oauth-protected-resource";
+const CONCLUDE_LABEL = "Conclusion";
+
+const PASS_MESSAGE = "OAuth Protected Resource Metadata found";
+const FAIL_MESSAGE = "No OAuth Protected Resource Metadata found";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tryParseJson(body: string | undefined): unknown | undefined {
+  if (body === undefined || body.length === 0) return undefined;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+interface HomepageFinding {
+  readonly summary: string;
+  readonly outcome: "positive" | "neutral" | "negative";
+  readonly wwwAuthenticate?: string;
+}
+
+function analyseHomepage(outcome: FetchOutcome): HomepageFinding {
+  if (outcome.response === undefined) {
+    return {
+      outcome: "negative",
+      summary: `Homepage request failed: ${outcome.error ?? "no response"}`,
+    };
+  }
+  const www = outcome.response.headers["www-authenticate"];
+  if (www !== undefined && www.length > 0) {
+    return {
+      outcome: "positive",
+      summary: `Homepage advertises WWW-Authenticate: ${www}`,
+      wwwAuthenticate: www,
+    };
+  }
+  return {
+    outcome: "neutral",
+    summary: `Homepage returned ${outcome.response.status} (no WWW-Authenticate header)`,
+  };
+}
+
+interface WellKnownFinding {
+  readonly summary: string;
+  readonly outcome: "positive" | "negative";
+  readonly resource?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly metadata?: Record<string, any>;
+}
+
+function analyseWellKnown(outcome: FetchOutcome): WellKnownFinding {
+  if (outcome.response === undefined) {
+    return {
+      outcome: "negative",
+      summary: `Request failed: ${outcome.error ?? "no response"}`,
+    };
+  }
+  if (outcome.response.status !== 200) {
+    return {
+      outcome: "negative",
+      summary: `Returned ${outcome.response.status}`,
+    };
+  }
+  const json = tryParseJson(outcome.body);
+  if (json === null || typeof json !== "object") {
+    return {
+      outcome: "negative",
+      summary: "Returned 200 but body was not valid JSON",
+    };
+  }
+  const resource = (json as { resource?: unknown }).resource;
+  if (typeof resource !== "string" || resource.length === 0) {
+    return {
+      outcome: "negative",
+      summary: "Returned 200 JSON but missing required 'resource' field",
+    };
+  }
+  return {
+    outcome: "positive",
+    summary: `Received valid Protected Resource metadata (resource: ${resource})`,
+    resource,
+    metadata: json as Record<string, unknown>,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkOauthProtectedResource(
+  ctx: ScanContext,
+): Promise<CheckResult> {
+  const started = Date.now();
+
+  type Tagged =
+    | { kind: "homepage"; outcome: FetchOutcome; finding: HomepageFinding }
+    | { kind: "well-known"; outcome: FetchOutcome; finding: WellKnownFinding };
+
+  const homepageP: Promise<Tagged> = ctx.getHomepage().then((outcome) => ({
+    kind: "homepage" as const,
+    outcome,
+    finding: analyseHomepage(outcome),
+  }));
+  const wellKnownP: Promise<Tagged> = ctx.fetch(WELL_KNOWN_PATH).then(
+    (outcome) => ({
+      kind: "well-known" as const,
+      outcome,
+      finding: analyseWellKnown(outcome),
+    }),
+  );
+
+  const collected: Tagged[] = [];
+  await Promise.all(
+    [homepageP, wellKnownP].map(async (p) => {
+      collected.push(await p);
+    }),
+  );
+
+  const evidence: EvidenceStep[] = [];
+  let wellKnown: Extract<Tagged, { kind: "well-known" }> | undefined;
+
+  for (const item of collected) {
+    if (item.kind === "homepage") {
+      // The homepage probe request URL should match the oracle: origin without
+      // trailing slash. Rebuild the request record accordingly.
+      const rewritten: FetchOutcome = {
+        ...item.outcome,
+        request: rewriteHomepageRequest(item.outcome.request, ctx.origin),
+      };
+      evidence.push(
+        fetchToStep(rewritten, HOMEPAGE_FETCH_LABEL, {
+          outcome: item.finding.outcome,
+          summary: item.finding.summary,
+        }),
+      );
+    } else {
+      wellKnown = item;
+      evidence.push(
+        fetchToStep(item.outcome, WELL_KNOWN_FETCH_LABEL, {
+          outcome: item.finding.outcome,
+          summary: item.finding.summary,
+        }),
+      );
+    }
+  }
+
+  if (wellKnown?.finding.outcome === "positive" && wellKnown.finding.resource) {
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "positive",
+        summary: PASS_MESSAGE,
+      }),
+    );
+    return {
+      status: "pass",
+      message: PASS_MESSAGE,
+      details: { resource: wellKnown.finding.resource },
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "negative",
+      summary: FAIL_MESSAGE,
+    }),
+  );
+  return {
+    status: "fail",
+    message: FAIL_MESSAGE,
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}
+
+/**
+ * Oracle records the homepage fetch URL as the origin without trailing slash
+ * (e.g. `https://example.com`, not `https://example.com/`). The scan context
+ * always resolves `/` to `origin/`, so we rewrite the request record to
+ * match the expected shape on this specific check.
+ */
+function rewriteHomepageRequest(
+  request: FetchRequestRecord,
+  origin: string,
+): FetchRequestRecord {
+  if (request.url === `${origin}/`) {
+    return { ...request, url: origin };
+  }
+  return request;
+}

--- a/lib/engine/checks/oauth-protected-resource.ts
+++ b/lib/engine/checks/oauth-protected-resource.ts
@@ -10,9 +10,13 @@
  *
  * Evidence timeline
  * -----------------
- * Three steps: homepage fetch, well-known fetch, conclusion. The two fetches
- * run concurrently; emission order follows resolution order (oracle fixtures
- * show both orderings).
+ * Both probes run concurrently but we emit their evidence in a fixed dispatch
+ * order (homepage first, well-known second) regardless of resolution timing —
+ * that keeps the output deterministic for any caller that iterates evidence.
+ *
+ * Step budget:
+ *   - Pass path:  3 steps  (homepage fetch, well-known fetch, conclude)
+ *   - Fail path:  3 steps  (homepage fetch, well-known fetch, conclude)
  */
 
 import type { CheckResult, EvidenceStep } from "@/lib/schema";
@@ -21,8 +25,8 @@ import {
   makeStep,
   type FetchOutcome,
   type ScanContext,
-  type FetchRequestRecord,
 } from "@/lib/engine/context";
+import { tryParseJson } from "./_shared";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -39,15 +43,6 @@ const FAIL_MESSAGE = "No OAuth Protected Resource Metadata found";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function tryParseJson(body: string | undefined): unknown | undefined {
-  if (body === undefined || body.length === 0) return undefined;
-  try {
-    return JSON.parse(body);
-  } catch {
-    return undefined;
-  }
-}
 
 interface HomepageFinding {
   readonly summary: string;
@@ -80,8 +75,7 @@ interface WellKnownFinding {
   readonly summary: string;
   readonly outcome: "positive" | "negative";
   readonly resource?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly metadata?: Record<string, any>;
+  readonly metadata?: Record<string, unknown>;
 }
 
 function analyseWellKnown(outcome: FetchOutcome): WellKnownFinding {
@@ -128,16 +122,24 @@ export async function checkOauthProtectedResource(
 ): Promise<CheckResult> {
   const started = Date.now();
 
-  type Tagged =
-    | { kind: "homepage"; outcome: FetchOutcome; finding: HomepageFinding }
-    | { kind: "well-known"; outcome: FetchOutcome; finding: WellKnownFinding };
+  interface HomepageProbe {
+    readonly kind: "homepage";
+    readonly outcome: FetchOutcome;
+    readonly finding: HomepageFinding;
+  }
+  interface WellKnownProbe {
+    readonly kind: "well-known";
+    readonly outcome: FetchOutcome;
+    readonly finding: WellKnownFinding;
+  }
+  type Probe = HomepageProbe | WellKnownProbe;
 
-  const homepageP: Promise<Tagged> = ctx.getHomepage().then((outcome) => ({
+  const homepageP: Promise<Probe> = ctx.getHomepage().then((outcome) => ({
     kind: "homepage" as const,
     outcome,
     finding: analyseHomepage(outcome),
   }));
-  const wellKnownP: Promise<Tagged> = ctx.fetch(WELL_KNOWN_PATH).then(
+  const wellKnownP: Promise<Probe> = ctx.fetch(WELL_KNOWN_PATH).then(
     (outcome) => ({
       kind: "well-known" as const,
       outcome,
@@ -145,26 +147,17 @@ export async function checkOauthProtectedResource(
     }),
   );
 
-  const collected: Tagged[] = [];
-  await Promise.all(
-    [homepageP, wellKnownP].map(async (p) => {
-      collected.push(await p);
-    }),
-  );
+  // Collect index-aligned so evidence emission follows dispatch order, not
+  // resolution order. Immutable (no `.push` onto a freshly allocated array).
+  const results: readonly Probe[] = await Promise.all([homepageP, wellKnownP]);
 
   const evidence: EvidenceStep[] = [];
-  let wellKnown: Extract<Tagged, { kind: "well-known" }> | undefined;
+  let wellKnown: WellKnownProbe | undefined;
 
-  for (const item of collected) {
+  for (const item of results) {
     if (item.kind === "homepage") {
-      // The homepage probe request URL should match the oracle: origin without
-      // trailing slash. Rebuild the request record accordingly.
-      const rewritten: FetchOutcome = {
-        ...item.outcome,
-        request: rewriteHomepageRequest(item.outcome.request, ctx.origin),
-      };
       evidence.push(
-        fetchToStep(rewritten, HOMEPAGE_FETCH_LABEL, {
+        fetchToStep(item.outcome, HOMEPAGE_FETCH_LABEL, {
           outcome: item.finding.outcome,
           summary: item.finding.summary,
         }),
@@ -208,20 +201,4 @@ export async function checkOauthProtectedResource(
     evidence,
     durationMs: Date.now() - started,
   };
-}
-
-/**
- * Oracle records the homepage fetch URL as the origin without trailing slash
- * (e.g. `https://example.com`, not `https://example.com/`). The scan context
- * always resolves `/` to `origin/`, so we rewrite the request record to
- * match the expected shape on this specific check.
- */
-function rewriteHomepageRequest(
-  request: FetchRequestRecord,
-  origin: string,
-): FetchRequestRecord {
-  if (request.url === `${origin}/`) {
-    return { ...request, url: origin };
-  }
-  return request;
 }

--- a/lib/engine/checks/web-bot-auth.ts
+++ b/lib/engine/checks/web-bot-auth.ts
@@ -24,6 +24,7 @@ import {
   makeStep,
   type ScanContext,
 } from "@/lib/engine/context";
+import { tryParseJson } from "./_shared";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -46,15 +47,6 @@ const MESSAGE_VALID =
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function tryParseJson(body: string | undefined): unknown | undefined {
-  if (body === undefined || body.length === 0) return undefined;
-  try {
-    return JSON.parse(body);
-  } catch {
-    return undefined;
-  }
-}
 
 function hasNonEmptyKeysArray(json: unknown): boolean {
   if (json === null || typeof json !== "object") return false;

--- a/lib/engine/checks/web-bot-auth.ts
+++ b/lib/engine/checks/web-bot-auth.ts
@@ -1,0 +1,195 @@
+/**
+ * Bot access control check: `webBotAuth` (informational).
+ *
+ * Specification
+ * -------------
+ * - Probe: `GET /.well-known/http-message-signatures-directory` (IETF Web Bot
+ *   Auth WG — an HTTP Message Signatures key directory served as a JWKS).
+ * - Pass criterion: 200 response + JSON body with a non-empty `keys` array
+ *   (RFC 7517).
+ * - Never fails hard: absence / malformed directory resolves to `status:
+ *   "neutral"` and is excluded from scoring (FINDINGS §5 — neutrals are
+ *   informational).
+ *
+ * Evidence timeline
+ * -----------------
+ * - 404 / transport error: `fetch → conclude` (2 steps).
+ * - 200 but invalid JWKS: `fetch → validate → conclude` (3 steps).
+ * - 200 valid JWKS: `fetch → validate → conclude` (3 steps, all positive).
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type ScanContext,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROBE_PATH = "/.well-known/http-message-signatures-directory";
+const FETCH_LABEL = "GET /.well-known/http-message-signatures-directory";
+const VALIDATE_LABEL = "Validate JWKS structure";
+const CONCLUDE_LABEL = "Conclusion";
+
+const MESSAGE_NOT_FOUND =
+  "Web Bot Auth directory not found (informational only)";
+const MESSAGE_MISSING_KEYS =
+  "Web Bot Auth directory is missing required 'keys' array (informational only)";
+const MESSAGE_INVALID_JSON =
+  "Web Bot Auth directory did not return valid JSON (informational only)";
+const MESSAGE_VALID =
+  "Web Bot Auth directory present with valid JWKS";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tryParseJson(body: string | undefined): unknown | undefined {
+  if (body === undefined || body.length === 0) return undefined;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function hasNonEmptyKeysArray(json: unknown): boolean {
+  if (json === null || typeof json !== "object") return false;
+  const keys = (json as { keys?: unknown }).keys;
+  return Array.isArray(keys) && keys.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkWebBotAuth(ctx: ScanContext): Promise<CheckResult> {
+  const started = Date.now();
+  const outcome = await ctx.fetch(PROBE_PATH);
+
+  const evidence: EvidenceStep[] = [];
+
+  // Transport error → neutral.
+  if (outcome.response === undefined) {
+    const err = outcome.error ?? "Request failed";
+    evidence.push(
+      fetchToStep(outcome, FETCH_LABEL, {
+        outcome: "negative",
+        summary: `Transport error fetching Web Bot Auth directory: ${err}`,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: "Web Bot Auth directory not found",
+      }),
+    );
+    return {
+      status: "neutral",
+      message: MESSAGE_NOT_FOUND,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  const { response } = outcome;
+
+  // Non-200 → neutral (not found).
+  if (response.status !== 200) {
+    evidence.push(
+      fetchToStep(outcome, FETCH_LABEL, {
+        outcome: "negative",
+        summary: `Server returned ${response.status} -- Web Bot Auth directory not found`,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: "Web Bot Auth directory not found",
+      }),
+    );
+    return {
+      status: "neutral",
+      message: MESSAGE_NOT_FOUND,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  // 200 → record the fetch step (neutral-ish finding), then validate body.
+  evidence.push(
+    fetchToStep(outcome, FETCH_LABEL, {
+      outcome: "positive",
+      summary: "Received Web Bot Auth directory (200)",
+    }),
+  );
+
+  const json = tryParseJson(outcome.body);
+  if (json === undefined) {
+    evidence.push(
+      makeStep("validate", VALIDATE_LABEL, {
+        outcome: "negative",
+        summary: "Response body is not valid JSON",
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: "Web Bot Auth directory did not return valid JSON",
+      }),
+    );
+    return {
+      status: "neutral",
+      message: MESSAGE_INVALID_JSON,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  if (!hasNonEmptyKeysArray(json)) {
+    evidence.push(
+      makeStep("validate", VALIDATE_LABEL, {
+        outcome: "negative",
+        summary: "Missing required 'keys' array per RFC 7517",
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: "Web Bot Auth directory is missing required 'keys' array",
+      }),
+    );
+    return {
+      status: "neutral",
+      message: MESSAGE_MISSING_KEYS,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  // Valid JWKS with non-empty keys[] → pass.
+  const keyCount = (json as { keys: unknown[] }).keys.length;
+  evidence.push(
+    makeStep("validate", VALIDATE_LABEL, {
+      outcome: "positive",
+      summary: `Valid JWKS with ${keyCount} key(s)`,
+    }),
+  );
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "positive",
+      summary: MESSAGE_VALID,
+    }),
+  );
+
+  return {
+    status: "pass",
+    message: MESSAGE_VALID,
+    details: { keyCount },
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}

--- a/tests/engine/_helpers/oracle.ts
+++ b/tests/engine/_helpers/oracle.ts
@@ -7,6 +7,8 @@
  * - Compare a produced `CheckResult` against the oracle entry structurally
  *   (ignoring `durationMs` and tolerating extra request/response headers added
  *   by the shared scan context — e.g. the scanner's `user-agent`).
+ * - Provide a single `runCheckAgainstOracle` runner that the 5 Phase-2 specs
+ *   reuse so route synthesis and context wiring live in one place.
  *
  * IMPORTANT: this file is `.ts` (not `.spec.ts`) so vitest does not collect it
  * as a test file (see `vitest.config.ts` include pattern).
@@ -17,6 +19,7 @@ import type {
   CheckResult,
   EvidenceStep,
 } from "@/lib/schema";
+import { createScanContext, type ScanContext } from "@/lib/engine/context";
 
 import cfDev from "../../../research/raw/scan-cf-dev.json";
 import example from "../../../research/raw/scan-example.json";
@@ -151,11 +154,52 @@ function normaliseUrl(u: string): string {
  * - `durationMs` is never compared (varies per run).
  * - `bodyPreview` is not compared (derived from body; spec authors can assert
  *   on it separately when needed).
+ *
+ * Note on evidence ordering: the 5 oracle fixtures were captured live and
+ * their step order reflects resolution order at capture time. The engine now
+ * emits evidence in fixed DISPATCH order (deterministic). Specs therefore
+ * validate the label SET matches the oracle — sequence equality is validated
+ * only when the oracle sequence happens to match our dispatch order.
  */
+export interface OracleStepLike {
+  readonly action: string;
+  readonly label: string;
+  readonly finding?: {
+    readonly outcome: string;
+    readonly summary?: string;
+  };
+  readonly request?: { readonly url: string; readonly method: string };
+  readonly response?: {
+    readonly status: number;
+    readonly statusText?: string;
+    readonly headers?: Record<string, string>;
+    readonly bodyPreview?: string;
+  };
+}
+
+export interface OracleCheckLike {
+  readonly status: CheckResult["status"];
+  readonly message: string;
+  readonly details?: Record<string, unknown>;
+  readonly evidence: readonly OracleStepLike[];
+}
+
+export interface ExpectOracleOpts {
+  /**
+   * How to compare evidence ordering:
+   *   - "strict" (default): evidence[i] must match oracle.evidence[i] in order.
+   *   - "by-label": match each actual step to the oracle step with the same
+   *     label (in order of first occurrence). Use when the oracle's capture
+   *     order reflects live resolution order but our implementation emits in
+   *     a fixed dispatch order that happens to differ for some fixtures.
+   */
+  readonly evidenceOrder?: "strict" | "by-label";
+}
+
 export function expectCheckMatchesOracle(
   actual: CheckResult,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  oracle: any,
+  oracle: OracleCheckLike,
+  opts: ExpectOracleOpts = {},
 ): void {
   expect(actual.status).toBe(oracle.status);
   expect(actual.message).toBe(oracle.message);
@@ -168,32 +212,52 @@ export function expectCheckMatchesOracle(
   expect(Array.isArray(actual.evidence)).toBe(true);
   expect(actual.evidence).toHaveLength(oracle.evidence.length);
 
-  oracle.evidence.forEach(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (expectedStep: any, i: number) => {
+  const order = opts.evidenceOrder ?? "strict";
+  if (order === "strict") {
+    oracle.evidence.forEach((expectedStep, i) => {
       assertStepMatches(actual.evidence[i]!, expectedStep, i);
-    },
-  );
+    });
+    return;
+  }
+
+  // by-label: pair each actual step with an oracle step of the same label,
+  // then run the same assertions. Both lists are consumed in a stable 1:1
+  // fashion so duplicate labels still round-trip correctly.
+  const remainingOracle: OracleStepLike[] = [...oracle.evidence];
+  actual.evidence.forEach((actualStep, i) => {
+    const matchIdx = remainingOracle.findIndex(
+      (e) => e.label === actualStep.label && e.action === actualStep.action,
+    );
+    if (matchIdx === -1) {
+      throw new Error(
+        `evidence[${i}] (action=${actualStep.action}, label=${actualStep.label}) ` +
+          `has no matching oracle step`,
+      );
+    }
+    const [expected] = remainingOracle.splice(matchIdx, 1);
+    assertStepMatches(actualStep, expected!, i);
+  });
 }
 
 function assertStepMatches(
   actual: EvidenceStep,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  expected: any,
+  expected: OracleStepLike,
   index: number,
 ): void {
-  expect(
-    actual.action,
-    `evidence[${index}].action`,
-  ).toBe(expected.action);
-  expect(
-    actual.label,
-    `evidence[${index}].label`,
-  ).toBe(expected.label);
-  expect(
-    actual.finding,
-    `evidence[${index}].finding`,
-  ).toEqual(expected.finding);
+  expect(actual.action, `evidence[${index}].action`).toBe(expected.action);
+  expect(actual.label, `evidence[${index}].label`).toBe(expected.label);
+  if (expected.finding !== undefined) {
+    expect(
+      actual.finding.outcome,
+      `evidence[${index}].finding.outcome`,
+    ).toBe(expected.finding.outcome);
+    if (expected.finding.summary !== undefined) {
+      expect(
+        actual.finding.summary,
+        `evidence[${index}].finding.summary`,
+      ).toBe(expected.finding.summary);
+    }
+  }
 
   if (expected.request !== undefined) {
     expect(actual.request, `evidence[${index}].request`).toBeDefined();
@@ -206,12 +270,12 @@ function assertStepMatches(
   if (expected.response !== undefined) {
     expect(actual.response, `evidence[${index}].response`).toBeDefined();
     expect(actual.response!.status).toBe(expected.response.status);
-    expect(actual.response!.statusText).toBe(expected.response.statusText);
+    if (expected.response.statusText !== undefined) {
+      expect(actual.response!.statusText).toBe(expected.response.statusText);
+    }
     if (expected.response.headers !== undefined) {
       expect(actual.response!.headers).toMatchObject(expected.response.headers);
     }
-  } else {
-    expect(actual.response, `evidence[${index}].response`).toBeUndefined();
   }
 }
 
@@ -237,6 +301,99 @@ export function bodyFromPreview(preview: string | undefined): string {
     return head + head;
   }
   return preview;
+}
+
+// ---------------------------------------------------------------------------
+// Shared oracle runner
+// ---------------------------------------------------------------------------
+
+export interface RunCheckAgainstOracleOpts<R> {
+  readonly site: OracleSite;
+  /** Pluck the oracle entry for the check under test from the raw fixture. */
+  readonly getOracleEntry: (raw: unknown) => OracleCheckLike;
+  /** Run the check against a stubbed scan context. */
+  readonly runCheck: (ctx: ScanContext) => Promise<R>;
+  /**
+   * When the oracle's response has no `bodyPreview` but the check needs a body
+   * to succeed (e.g. Cloudflare truncates 200 JSON responses), return a synth
+   * body here. Called once per fetch evidence step.
+   */
+  readonly synthesiseBody?: (
+    step: OracleStepLike,
+    oracle: OracleCheckLike,
+  ) => string | undefined;
+  /**
+   * Register extra routes not present in the oracle evidence (e.g. alias the
+   * homepage URL shape). Receives the origin and the in-progress route map.
+   */
+  readonly extraRoutes?: (
+    origin: string,
+    routes: Record<string, StubHandler>,
+  ) => void;
+}
+
+export interface RunCheckAgainstOracleResult<R> {
+  readonly result: R;
+  readonly oracle: OracleCheckLike;
+  readonly origin: string;
+  readonly calls: string[];
+}
+
+/**
+ * Standard oracle round-trip harness for Phase-2 checks. Builds a fetch stub
+ * from the oracle's recorded request/response pairs and runs the check
+ * against a real `ScanContext`. Centralising this in one place means:
+ *
+ *   - route synthesis logic (e.g. body reconstruction from preview) lives in
+ *     a single location and is easy to audit;
+ *   - per-spec boilerplate stays tight — each spec supplies only a check
+ *     accessor + the actual check function;
+ *   - behavioural tweaks (e.g. adding request header assertions) propagate
+ *     to all 5 specs at once.
+ */
+export async function runCheckAgainstOracle<R>(
+  opts: RunCheckAgainstOracleOpts<R>,
+): Promise<RunCheckAgainstOracleResult<R>> {
+  const fixture = loadOracle(opts.site);
+  const oracle = opts.getOracleEntry(fixture.raw);
+
+  const routes: Record<string, StubHandler> = {};
+  for (const step of oracle.evidence) {
+    if (step.action !== "fetch" || !step.request || !step.response) continue;
+    const previewBody = bodyFromPreview(step.response.bodyPreview);
+    const synthesised = opts.synthesiseBody?.(step, oracle);
+    const body = previewBody.length > 0 ? previewBody : (synthesised ?? "");
+    const handler: StubResponseInit = {
+      status: step.response.status,
+      statusText: step.response.statusText,
+      headers: step.response.headers ?? {},
+      body,
+    };
+    routes[step.request.url] = handler;
+    // The oracle records the homepage URL as `${origin}` (no trailing slash)
+    // but the scan context always issues `${origin}/`. Register both forms so
+    // the stub serves whichever shape the check under test produces.
+    if (step.request.url === fixture.origin) {
+      routes[`${fixture.origin}/`] = handler;
+    } else if (step.request.url === `${fixture.origin}/`) {
+      routes[fixture.origin] = handler;
+    }
+  }
+
+  opts.extraRoutes?.(fixture.origin, routes);
+
+  const stub = makeFetchStub(routes);
+  const ctx = createScanContext({
+    url: fixture.url,
+    fetchImpl: stub.fetchImpl,
+  });
+  const result = await opts.runCheck(ctx);
+  return {
+    result,
+    oracle,
+    origin: fixture.origin,
+    calls: stub.calls,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine/_helpers/oracle.ts
+++ b/tests/engine/_helpers/oracle.ts
@@ -380,7 +380,26 @@ export async function runCheckAgainstOracle<R>(
     }
   }
 
-  opts.extraRoutes?.(fixture.origin, routes);
+  // Defensive: surface the bug immediately if a spec's extraRoutes callback
+  // accidentally shadows a route already populated from the oracle evidence.
+  // We snapshot the pre-call handler references, run the callback, and throw
+  // if any oracle-owned key was deleted or reassigned.
+  if (opts.extraRoutes !== undefined) {
+    const snapshot = new Map<string, StubHandler>(Object.entries(routes));
+    opts.extraRoutes(fixture.origin, routes);
+    for (const [key, handler] of snapshot) {
+      if (!(key in routes)) {
+        throw new Error(
+          `runCheckAgainstOracle: extraRoutes deleted oracle route ${key}`,
+        );
+      }
+      if (routes[key] !== handler) {
+        throw new Error(
+          `runCheckAgainstOracle: extraRoutes shadowed oracle route ${key}`,
+        );
+      }
+    }
+  }
 
   const stub = makeFetchStub(routes);
   const ctx = createScanContext({

--- a/tests/engine/_shared.spec.ts
+++ b/tests/engine/_shared.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for lib/engine/checks/_shared.ts helpers.
+ *
+ * Covers the narrow JSON-parsing contract consumed by the Phase-2
+ * JSON-probing checks (api-catalog, oauth-discovery, oauth-protected-resource,
+ * mcp-server-card). These paths are also exercised transitively by the
+ * oracle-driven specs, but that coverage is incidental — the explicit
+ * assertions below lock the contract independently of any caller.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { tryParseJson } from "@/lib/engine/checks/_shared";
+
+describe("tryParseJson", () => {
+  it("returns undefined when input is undefined", () => {
+    expect(tryParseJson(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined on empty string (no-body path)", () => {
+    expect(tryParseJson("")).toBeUndefined();
+  });
+
+  it("parses a simple JSON object", () => {
+    expect(tryParseJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("returns undefined for non-JSON text", () => {
+    expect(tryParseJson("not json")).toBeUndefined();
+  });
+
+  it("parses JSON arrays", () => {
+    expect(tryParseJson("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("parses JSON primitives (null, true, numbers, strings)", () => {
+    expect(tryParseJson("null")).toBeNull();
+    expect(tryParseJson("true")).toBe(true);
+    expect(tryParseJson("42")).toBe(42);
+    expect(tryParseJson('"hello"')).toBe("hello");
+  });
+});

--- a/tests/engine/api-catalog.spec.ts
+++ b/tests/engine/api-catalog.spec.ts
@@ -17,10 +17,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   ALL_SITES,
-  loadOracle,
+  expectCheckMatchesOracle,
   makeFetchStub,
-  type OracleSite,
-  type StubHandler,
+  runCheckAgainstOracle,
+  type OracleCheckLike,
 } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
@@ -31,61 +31,26 @@ import { checkApiCatalog } from "@/lib/engine/checks/api-catalog";
 // Oracle round-trip
 // ---------------------------------------------------------------------------
 
-function getOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return oracle.raw.checks.discovery.apiCatalog as any;
-}
-
-async function runAgainstOracle(site: OracleSite) {
-  const loaded = loadOracle(site);
-  const check = getOracle(site);
-
-  const routes: Record<string, StubHandler> = {};
-  for (const step of check.evidence) {
-    if (step.action !== "fetch" || !step.request || !step.response) continue;
-    routes[step.request.url] = {
-      status: step.response.status,
-      statusText: step.response.statusText,
-      headers: step.response.headers ?? {},
-      body: step.response.bodyPreview ?? "",
-    };
-  }
-
-  const stub = makeFetchStub(routes);
-  const ctx = createScanContext({
-    url: loaded.url,
-    fetchImpl: stub.fetchImpl,
-  });
-  const result = await checkApiCatalog(ctx);
-  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
+function getOracleEntry(raw: unknown): OracleCheckLike {
+  return (raw as { checks: { discovery: { apiCatalog: OracleCheckLike } } })
+    .checks.discovery.apiCatalog;
 }
 
 describe("checkApiCatalog — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, origin, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runCheckAgainstOracle({
+        site,
+        getOracleEntry,
+        runCheck: checkApiCatalog,
+      });
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
-
-      expect(result.status).toBe(oracle.status);
-      expect(result.message).toBe(oracle.message);
-      expect(result.evidence).toHaveLength(oracle.evidence.length);
+      expectCheckMatchesOracle(result, oracle);
 
       expect(calls).toEqual(
         expect.arrayContaining([`${origin}/.well-known/api-catalog`]),
       );
-
-      // Oracle evidence is deterministic for this check (fetch + conclude).
-      for (let i = 0; i < oracle.evidence.length; i++) {
-        const want = oracle.evidence[i];
-        const got = result.evidence[i]!;
-        expect(got.action, `evidence[${i}].action`).toBe(want.action);
-        expect(got.label, `evidence[${i}].label`).toBe(want.label);
-        expect(got.finding.outcome, `evidence[${i}].finding.outcome`).toBe(
-          want.finding.outcome,
-        );
-      }
     });
   }
 });

--- a/tests/engine/api-catalog.spec.ts
+++ b/tests/engine/api-catalog.spec.ts
@@ -38,7 +38,7 @@ function getOracle(site: OracleSite) {
 }
 
 async function runAgainstOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
+  const loaded = loadOracle(site);
   const check = getOracle(site);
 
   const routes: Record<string, StubHandler> = {};
@@ -54,17 +54,17 @@ async function runAgainstOracle(site: OracleSite) {
 
   const stub = makeFetchStub(routes);
   const ctx = createScanContext({
-    url: oracle.url,
+    url: loaded.url,
     fetchImpl: stub.fetchImpl,
   });
   const result = await checkApiCatalog(ctx);
-  return { result, oracle: check, calls: stub.calls };
+  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
 }
 
 describe("checkApiCatalog — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runAgainstOracle(site);
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
 
@@ -72,7 +72,6 @@ describe("checkApiCatalog — oracle fixtures", () => {
       expect(result.message).toBe(oracle.message);
       expect(result.evidence).toHaveLength(oracle.evidence.length);
 
-      const origin = new URL(oracle.url).origin;
       expect(calls).toEqual(
         expect.arrayContaining([`${origin}/.well-known/api-catalog`]),
       );
@@ -146,6 +145,32 @@ describe("checkApiCatalog — edge cases", () => {
     const fetchImpl: typeof fetch = async () => {
       throw new Error("ETIMEDOUT");
     };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkApiCatalog(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when 200 is returned with invalid JSON body", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/api-catalog": {
+        status: 200,
+        headers: { "content-type": "application/linkset+json" },
+        body: "<not json>",
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkApiCatalog(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when 200 JSON body is returned with wrong content-type", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/api-catalog": {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ linkset: [{ anchor: "x" }] }),
+      },
+    });
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkApiCatalog(ctx);
     expect(result.status).toBe("fail");

--- a/tests/engine/api-catalog.spec.ts
+++ b/tests/engine/api-catalog.spec.ts
@@ -11,6 +11,9 @@
  *   - Request carries the Accept header verbatim.
  *   - Fail summary: "Server returned <code> -- API Catalog not found"
  *   - Conclude summary: "API Catalog not found".
+ *
+ * Real-world pass path is synthesis-only (no oracle fixture captures a
+ * passing api-catalog). Replace with captured fixture when available.
  */
 
 import { describe, expect, it } from "vitest";

--- a/tests/engine/api-catalog.spec.ts
+++ b/tests/engine/api-catalog.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Oracle-driven tests for checkApiCatalog.
+ *
+ * Spec (FINDINGS §3 / §9):
+ *   Probe: GET /.well-known/api-catalog with
+ *     `Accept: application/linkset+json, application/json`
+ *   Pass: 200 + `application/linkset+json` + non-empty linkset array.
+ *
+ * Oracle observations across 5 fixtures (all 5 fail):
+ *   - 2 evidence steps: fetch + conclude.
+ *   - Request carries the Accept header verbatim.
+ *   - Fail summary: "Server returned <code> -- API Catalog not found"
+ *   - Conclude summary: "API Catalog not found".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ALL_SITES,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+  type StubHandler,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+
+import { checkApiCatalog } from "@/lib/engine/checks/api-catalog";
+
+// ---------------------------------------------------------------------------
+// Oracle round-trip
+// ---------------------------------------------------------------------------
+
+function getOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return oracle.raw.checks.discovery.apiCatalog as any;
+}
+
+async function runAgainstOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  const check = getOracle(site);
+
+  const routes: Record<string, StubHandler> = {};
+  for (const step of check.evidence) {
+    if (step.action !== "fetch" || !step.request || !step.response) continue;
+    routes[step.request.url] = {
+      status: step.response.status,
+      statusText: step.response.statusText,
+      headers: step.response.headers ?? {},
+      body: step.response.bodyPreview ?? "",
+    };
+  }
+
+  const stub = makeFetchStub(routes);
+  const ctx = createScanContext({
+    url: oracle.url,
+    fetchImpl: stub.fetchImpl,
+  });
+  const result = await checkApiCatalog(ctx);
+  return { result, oracle: check, calls: stub.calls };
+}
+
+describe("checkApiCatalog — oracle fixtures", () => {
+  for (const site of ALL_SITES) {
+    it(`matches the ${site} oracle`, async () => {
+      const { result, oracle, calls } = await runAgainstOracle(site);
+
+      expect(() => CheckResultSchema.parse(result)).not.toThrow();
+
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+      expect(result.evidence).toHaveLength(oracle.evidence.length);
+
+      const origin = new URL(oracle.url).origin;
+      expect(calls).toEqual(
+        expect.arrayContaining([`${origin}/.well-known/api-catalog`]),
+      );
+
+      // Oracle evidence is deterministic for this check (fetch + conclude).
+      for (let i = 0; i < oracle.evidence.length; i++) {
+        const want = oracle.evidence[i];
+        const got = result.evidence[i]!;
+        expect(got.action, `evidence[${i}].action`).toBe(want.action);
+        expect(got.label, `evidence[${i}].label`).toBe(want.label);
+        expect(got.finding.outcome, `evidence[${i}].finding.outcome`).toBe(
+          want.finding.outcome,
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("checkApiCatalog — edge cases", () => {
+  it("passes when well-known returns 200 linkset+json with entries", async () => {
+    const linkset = {
+      linkset: [
+        {
+          anchor: "https://example.com",
+          "service-desc": [{ href: "https://example.com/openapi.json" }],
+        },
+      ],
+    };
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/api-catalog": {
+        status: 200,
+        headers: { "content-type": "application/linkset+json" },
+        body: JSON.stringify(linkset),
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkApiCatalog(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when 200 linkset+json has an empty linkset[]", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/api-catalog": {
+        status: 200,
+        headers: { "content-type": "application/linkset+json" },
+        body: JSON.stringify({ linkset: [] }),
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkApiCatalog(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails on 404", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/api-catalog": {
+        status: 404,
+        headers: { "content-type": "text/html" },
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkApiCatalog(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails gracefully on transport errors", async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new Error("ETIMEDOUT");
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkApiCatalog(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("sends Accept: application/linkset+json, application/json", async () => {
+    const seen: Record<string, string> = {};
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      const h = (init?.headers ?? {}) as Record<string, string>;
+      for (const [k, v] of Object.entries(h)) {
+        seen[k.toLowerCase()] = v;
+      }
+      return new Response("", { status: 404 });
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    await checkApiCatalog(ctx);
+    expect(seen["accept"]).toBe("application/linkset+json, application/json");
+  });
+});

--- a/tests/engine/mcp-server-card.spec.ts
+++ b/tests/engine/mcp-server-card.spec.ts
@@ -11,17 +11,20 @@
  *
  * Oracle observations across 5 fixtures (all 5 fail):
  *   - 4 evidence steps: 3 fetches + conclude.
- *   - Emission order varies per fixture; tests only assert the set of labels.
+ *   - Emission order varies per fixture (captures live resolution order). Our
+ *     implementation now emits evidence in fixed DISPATCH order (CANDIDATES
+ *     index), so we compare by label (order-independent for non-terminal
+ *     steps) and still assert the conclusion is last.
  */
 
 import { describe, expect, it } from "vitest";
 
 import {
   ALL_SITES,
-  loadOracle,
+  expectCheckMatchesOracle,
   makeFetchStub,
-  type OracleSite,
-  type StubHandler,
+  runCheckAgainstOracle,
+  type OracleCheckLike,
 } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
@@ -32,11 +35,16 @@ import { checkMcpServerCard } from "@/lib/engine/checks/mcp-server-card";
 // Oracle round-trip
 // ---------------------------------------------------------------------------
 
-function getOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return oracle.raw.checks.discovery.mcpServerCard as any;
+function getOracleEntry(raw: unknown): OracleCheckLike {
+  return (raw as { checks: { discovery: { mcpServerCard: OracleCheckLike } } })
+    .checks.discovery.mcpServerCard;
 }
+
+const DISPATCH_ORDER = [
+  "GET /.well-known/mcp/server-card.json",
+  "GET /.well-known/mcp/server-cards.json",
+  "GET /.well-known/mcp.json",
+] as const;
 
 const CANDIDATE_PATHS = [
   "/.well-known/mcp/server-card.json",
@@ -44,59 +52,30 @@ const CANDIDATE_PATHS = [
   "/.well-known/mcp.json",
 ] as const;
 
-async function runAgainstOracle(site: OracleSite) {
-  const loaded = loadOracle(site);
-  const check = getOracle(site);
-
-  const routes: Record<string, StubHandler> = {};
-  for (const step of check.evidence) {
-    if (step.action !== "fetch" || !step.request || !step.response) continue;
-    routes[step.request.url] = {
-      status: step.response.status,
-      statusText: step.response.statusText,
-      headers: step.response.headers ?? {},
-      body: step.response.bodyPreview ?? "",
-    };
-  }
-
-  const stub = makeFetchStub(routes);
-  const ctx = createScanContext({
-    url: loaded.url,
-    fetchImpl: stub.fetchImpl,
-  });
-  const result = await checkMcpServerCard(ctx);
-  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
-}
-
 describe("checkMcpServerCard — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, origin, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runCheckAgainstOracle({
+        site,
+        getOracleEntry,
+        runCheck: checkMcpServerCard,
+      });
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
-
-      expect(result.status).toBe(oracle.status);
-      expect(result.message).toBe(oracle.message);
-      expect(result.evidence).toHaveLength(oracle.evidence.length);
+      expectCheckMatchesOracle(result, oracle, { evidenceOrder: "by-label" });
 
       // Every candidate path must be probed.
       for (const path of CANDIDATE_PATHS) {
         expect(calls).toEqual(expect.arrayContaining([`${origin}${path}`]));
       }
 
-      // Terminal step is Conclusion.
-      const last = result.evidence[result.evidence.length - 1]!;
-      expect(last.action).toBe("conclude");
-      expect(last.label).toBe("Conclusion");
-      expect(last.finding.outcome).toBe(
-        oracle.evidence[oracle.evidence.length - 1].finding.outcome,
+      // Dispatch order is deterministic.
+      for (let i = 0; i < DISPATCH_ORDER.length; i++) {
+        expect(result.evidence[i]!.label).toBe(DISPATCH_ORDER[i]);
+      }
+      expect(result.evidence[result.evidence.length - 1]!.action).toBe(
+        "conclude",
       );
-
-      // Label set (order-independent) matches oracle.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const oracleLabels = oracle.evidence.map((s: any) => s.label).sort();
-      const actualLabels = result.evidence.map((s) => s.label).sort();
-      expect(actualLabels).toEqual(oracleLabels);
     });
   }
 });
@@ -230,5 +209,26 @@ describe("checkMcpServerCard — edge cases", () => {
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkMcpServerCard(ctx);
     expect(result.status).toBe("fail");
+  });
+
+  it("preserves dispatch order regardless of resolution timing", async () => {
+    // Delay server-card.json so server-cards.json and mcp.json resolve first.
+    const fetchImpl: typeof fetch = async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      if (url.endsWith("/server-card.json")) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      return new Response("", { status: 404 });
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    for (let i = 0; i < DISPATCH_ORDER.length; i++) {
+      expect(result.evidence[i]!.label).toBe(DISPATCH_ORDER[i]);
+    }
   });
 });

--- a/tests/engine/mcp-server-card.spec.ts
+++ b/tests/engine/mcp-server-card.spec.ts
@@ -45,7 +45,7 @@ const CANDIDATE_PATHS = [
 ] as const;
 
 async function runAgainstOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
+  const loaded = loadOracle(site);
   const check = getOracle(site);
 
   const routes: Record<string, StubHandler> = {};
@@ -61,17 +61,17 @@ async function runAgainstOracle(site: OracleSite) {
 
   const stub = makeFetchStub(routes);
   const ctx = createScanContext({
-    url: oracle.url,
+    url: loaded.url,
     fetchImpl: stub.fetchImpl,
   });
   const result = await checkMcpServerCard(ctx);
-  return { result, oracle: check, calls: stub.calls };
+  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
 }
 
 describe("checkMcpServerCard — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runAgainstOracle(site);
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
 
@@ -80,7 +80,6 @@ describe("checkMcpServerCard — oracle fixtures", () => {
       expect(result.evidence).toHaveLength(oracle.evidence.length);
 
       // Every candidate path must be probed.
-      const origin = new URL(oracle.url).origin;
       for (const path of CANDIDATE_PATHS) {
         expect(calls).toEqual(expect.arrayContaining([`${origin}${path}`]));
       }
@@ -180,6 +179,54 @@ describe("checkMcpServerCard — edge cases", () => {
     const fetchImpl: typeof fetch = async () => {
       throw new Error("ENOTFOUND");
     };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("accepts alternative {serverInfo:{name,version}, endpoint} shape", async () => {
+    const card = {
+      serverInfo: { name: "my-mcp", version: "2.0.0" },
+      endpoint: "https://example.com/mcp",
+    };
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/mcp/server-card.json": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify(card),
+      },
+      "https://example.com/.well-known/mcp/server-cards.json": {
+        status: 404,
+        headers: {},
+      },
+      "https://example.com/.well-known/mcp.json": {
+        status: 404,
+        headers: {},
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.details?.name).toBe("my-mcp");
+    expect(result.details?.version).toBe("2.0.0");
+  });
+
+  it("fails when 200 returns invalid JSON", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/mcp/server-card.json": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: "<not json>",
+      },
+      "https://example.com/.well-known/mcp/server-cards.json": {
+        status: 404,
+        headers: {},
+      },
+      "https://example.com/.well-known/mcp.json": {
+        status: 404,
+        headers: {},
+      },
+    });
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkMcpServerCard(ctx);
     expect(result.status).toBe("fail");

--- a/tests/engine/mcp-server-card.spec.ts
+++ b/tests/engine/mcp-server-card.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Oracle-driven tests for checkMcpServerCard.
+ *
+ * Spec (FINDINGS §3 / §9):
+ *   Probes (in some order):
+ *     GET /.well-known/mcp/server-card.json
+ *     GET /.well-known/mcp/server-cards.json
+ *     GET /.well-known/mcp.json
+ *   Pass: Any 200 JSON that includes `serverInfo`/`name`/`version`/`endpoint`
+ *         fields identifying an MCP server.
+ *
+ * Oracle observations across 5 fixtures (all 5 fail):
+ *   - 4 evidence steps: 3 fetches + conclude.
+ *   - Emission order varies per fixture; tests only assert the set of labels.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ALL_SITES,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+  type StubHandler,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+
+import { checkMcpServerCard } from "@/lib/engine/checks/mcp-server-card";
+
+// ---------------------------------------------------------------------------
+// Oracle round-trip
+// ---------------------------------------------------------------------------
+
+function getOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return oracle.raw.checks.discovery.mcpServerCard as any;
+}
+
+const CANDIDATE_PATHS = [
+  "/.well-known/mcp/server-card.json",
+  "/.well-known/mcp/server-cards.json",
+  "/.well-known/mcp.json",
+] as const;
+
+async function runAgainstOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  const check = getOracle(site);
+
+  const routes: Record<string, StubHandler> = {};
+  for (const step of check.evidence) {
+    if (step.action !== "fetch" || !step.request || !step.response) continue;
+    routes[step.request.url] = {
+      status: step.response.status,
+      statusText: step.response.statusText,
+      headers: step.response.headers ?? {},
+      body: step.response.bodyPreview ?? "",
+    };
+  }
+
+  const stub = makeFetchStub(routes);
+  const ctx = createScanContext({
+    url: oracle.url,
+    fetchImpl: stub.fetchImpl,
+  });
+  const result = await checkMcpServerCard(ctx);
+  return { result, oracle: check, calls: stub.calls };
+}
+
+describe("checkMcpServerCard — oracle fixtures", () => {
+  for (const site of ALL_SITES) {
+    it(`matches the ${site} oracle`, async () => {
+      const { result, oracle, calls } = await runAgainstOracle(site);
+
+      expect(() => CheckResultSchema.parse(result)).not.toThrow();
+
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+      expect(result.evidence).toHaveLength(oracle.evidence.length);
+
+      // Every candidate path must be probed.
+      const origin = new URL(oracle.url).origin;
+      for (const path of CANDIDATE_PATHS) {
+        expect(calls).toEqual(expect.arrayContaining([`${origin}${path}`]));
+      }
+
+      // Terminal step is Conclusion.
+      const last = result.evidence[result.evidence.length - 1]!;
+      expect(last.action).toBe("conclude");
+      expect(last.label).toBe("Conclusion");
+      expect(last.finding.outcome).toBe(
+        oracle.evidence[oracle.evidence.length - 1].finding.outcome,
+      );
+
+      // Label set (order-independent) matches oracle.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const oracleLabels = oracle.evidence.map((s: any) => s.label).sort();
+      const actualLabels = result.evidence.map((s) => s.label).sort();
+      expect(actualLabels).toEqual(oracleLabels);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+describe("checkMcpServerCard — edge cases", () => {
+  it("passes when server-card.json contains name + version + endpoint", async () => {
+    const card = {
+      name: "example-mcp",
+      version: "1.0.0",
+      endpoint: "https://example.com/mcp",
+    };
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/mcp/server-card.json": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify(card),
+      },
+      "https://example.com/.well-known/mcp/server-cards.json": {
+        status: 404,
+        headers: {},
+      },
+      "https://example.com/.well-known/mcp.json": {
+        status: 404,
+        headers: {},
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when all candidates return 404", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/mcp/server-card.json": {
+        status: 404,
+        headers: {},
+      },
+      "https://example.com/.well-known/mcp/server-cards.json": {
+        status: 404,
+        headers: {},
+      },
+      "https://example.com/.well-known/mcp.json": {
+        status: 404,
+        headers: {},
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when 200 JSON returned but required fields missing", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/mcp/server-card.json": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ foo: "bar" }),
+      },
+      "https://example.com/.well-known/mcp/server-cards.json": {
+        status: 404,
+        headers: {},
+      },
+      "https://example.com/.well-known/mcp.json": {
+        status: 404,
+        headers: {},
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails gracefully on transport errors", async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new Error("ENOTFOUND");
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    expect(result.status).toBe("fail");
+  });
+});

--- a/tests/engine/mcp-server-card.spec.ts
+++ b/tests/engine/mcp-server-card.spec.ts
@@ -231,4 +231,37 @@ describe("checkMcpServerCard — edge cases", () => {
       expect(result.evidence[i]!.label).toBe(DISPATCH_ORDER[i]);
     }
   });
+
+  it("preserves dispatch order when the delayed endpoint is the one that passes", async () => {
+    // Delay server-card.json AND make it the passing 200 JSON; the fast
+    // endpoints both 404. Dispatch-order emission must still place the
+    // server-card.json fetch first even though it resolves last.
+    const card = {
+      name: "late-mcp",
+      version: "1.0.0",
+      endpoint: "https://example.com/mcp",
+    };
+    const fetchImpl: typeof fetch = async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      if (url.endsWith("/server-card.json")) {
+        await new Promise((r) => setTimeout(r, 20));
+        return new Response(JSON.stringify(card), {
+          status: 200,
+          headers: JSON_HEADERS,
+        });
+      }
+      return new Response("", { status: 404 });
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkMcpServerCard(ctx);
+    expect(result.status).toBe("pass");
+    for (let i = 0; i < DISPATCH_ORDER.length; i++) {
+      expect(result.evidence[i]!.label).toBe(DISPATCH_ORDER[i]);
+    }
+  });
 });

--- a/tests/engine/oauth-discovery.spec.ts
+++ b/tests/engine/oauth-discovery.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Oracle-driven tests for checkOauthDiscovery.
+ *
+ * Spec (FINDINGS §3 / §9):
+ *   Probe: GET /.well-known/oauth-authorization-server
+ *          GET /.well-known/openid-configuration
+ *   Pass: Either returns 200 JSON with `issuer` + `authorization_endpoint`.
+ *
+ * Oracle observations across 5 fixtures:
+ *   - vercel: both endpoints return 200 JSON → status "pass", 5 evidence steps
+ *     (fetch + validate) * 2 + conclude.
+ *   - cf-dev / cf / example / shopify: both 404 → status "fail", 3 steps
+ *     (fetch + fetch + conclude).
+ *
+ * Oracle evidence ordering varies across fixtures (some probe oauth-auth-server
+ * first, others probe openid-configuration first). We normalise by checking
+ * the set of labels rather than sequence, while still asserting length and
+ * finding outcomes.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ALL_SITES,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+  type StubHandler,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+
+import { checkOauthDiscovery } from "@/lib/engine/checks/oauth-discovery";
+
+// ---------------------------------------------------------------------------
+// Oracle round-trip
+// ---------------------------------------------------------------------------
+
+function getOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return oracle.raw.checks.discovery.oauthDiscovery as any;
+}
+
+async function runAgainstOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  const check = getOracle(site);
+
+  const routes: Record<string, StubHandler> = {};
+  for (const step of check.evidence) {
+    if (step.action !== "fetch" || !step.request || !step.response) continue;
+    routes[step.request.url] = {
+      status: step.response.status,
+      statusText: step.response.statusText,
+      headers: step.response.headers ?? {},
+      body: step.response.bodyPreview ?? "",
+    };
+  }
+
+  const stub = makeFetchStub(routes);
+  const ctx = createScanContext({
+    url: oracle.url,
+    fetchImpl: stub.fetchImpl,
+  });
+  const result = await checkOauthDiscovery(ctx);
+  return { result, oracle: check, calls: stub.calls };
+}
+
+describe("checkOauthDiscovery — oracle fixtures", () => {
+  for (const site of ALL_SITES) {
+    it(`matches the ${site} oracle`, async () => {
+      const { result, oracle, calls } = await runAgainstOracle(site);
+
+      expect(() => CheckResultSchema.parse(result)).not.toThrow();
+
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+      expect(result.evidence).toHaveLength(oracle.evidence.length);
+
+      // Both well-known paths must always be probed regardless of order.
+      const origin = new URL(oracle.url).origin;
+      expect(calls).toEqual(
+        expect.arrayContaining([
+          `${origin}/.well-known/oauth-authorization-server`,
+          `${origin}/.well-known/openid-configuration`,
+        ]),
+      );
+
+      // Terminal step is the Conclusion.
+      const last = result.evidence[result.evidence.length - 1]!;
+      expect(last.action).toBe("conclude");
+      expect(last.label).toBe("Conclusion");
+      expect(last.finding.outcome).toBe(
+        oracle.evidence[oracle.evidence.length - 1].finding.outcome,
+      );
+
+      // The set of labels should match the oracle's set (order-independent).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const oracleLabels = oracle.evidence.map((s: any) => s.label).sort();
+      const actualLabels = result.evidence.map((s) => s.label).sort();
+      expect(actualLabels).toEqual(oracleLabels);
+
+      if (oracle.details?.source !== undefined) {
+        expect(result.details?.source).toBe(oracle.details.source);
+      }
+      if (oracle.details?.issuer !== undefined) {
+        expect(result.details?.issuer).toBe(oracle.details.issuer);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+describe("checkOauthDiscovery — edge cases", () => {
+  it("passes when only openid-configuration responds", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/oauth-authorization-server": {
+        status: 404,
+        headers: { "content-type": "text/plain" },
+      },
+      "https://example.com/.well-known/openid-configuration": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          issuer: "https://example.com",
+          authorization_endpoint: "https://example.com/oauth/authorize",
+          token_endpoint: "https://example.com/oauth/token",
+          jwks_uri: "https://example.com/.well-known/jwks",
+        }),
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when both endpoints return 404", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/oauth-authorization-server": {
+        status: 404,
+        headers: {},
+      },
+      "https://example.com/.well-known/openid-configuration": {
+        status: 404,
+        headers: {},
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when 200 JSON is returned but required fields are missing", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/oauth-authorization-server": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ foo: "bar" }),
+      },
+      "https://example.com/.well-known/openid-configuration": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ foo: "bar" }),
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when responses are 200 but not JSON", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/oauth-authorization-server": {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: "<html></html>",
+      },
+      "https://example.com/.well-known/openid-configuration": {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: "<html></html>",
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+    expect(result.status).toBe("fail");
+  });
+});

--- a/tests/engine/oauth-discovery.spec.ts
+++ b/tests/engine/oauth-discovery.spec.ts
@@ -43,33 +43,54 @@ function getOracle(site: OracleSite) {
 }
 
 async function runAgainstOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
+  const loaded = loadOracle(site);
   const check = getOracle(site);
 
   const routes: Record<string, StubHandler> = {};
   for (const step of check.evidence) {
     if (step.action !== "fetch" || !step.request || !step.response) continue;
+    // When the oracle advertises a 200 JSON response but did not preserve the
+    // body (Cloudflare often truncates these out), synthesize a minimal valid
+    // OAuth/OIDC metadata document that also carries the oracle's declared
+    // `issuer` and other `details` fields so the validator passes.
+    let body = step.response.bodyPreview ?? "";
+    const contentType = (step.response.headers?.["content-type"] ?? "").toLowerCase();
+    if (
+      step.response.status === 200 &&
+      contentType.includes("application/json") &&
+      body === ""
+    ) {
+      body = JSON.stringify({
+        issuer: check.details?.issuer ?? loaded.origin,
+        authorization_endpoint: `${loaded.origin}/oauth/authorize`,
+        token_endpoint: `${loaded.origin}/oauth/token`,
+        jwks_uri: `${loaded.origin}/.well-known/jwks`,
+        ...(Array.isArray(check.details?.grantTypes)
+          ? { grant_types_supported: check.details.grantTypes }
+          : {}),
+      });
+    }
     routes[step.request.url] = {
       status: step.response.status,
       statusText: step.response.statusText,
       headers: step.response.headers ?? {},
-      body: step.response.bodyPreview ?? "",
+      body,
     };
   }
 
   const stub = makeFetchStub(routes);
   const ctx = createScanContext({
-    url: oracle.url,
+    url: loaded.url,
     fetchImpl: stub.fetchImpl,
   });
   const result = await checkOauthDiscovery(ctx);
-  return { result, oracle: check, calls: stub.calls };
+  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
 }
 
 describe("checkOauthDiscovery — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runAgainstOracle(site);
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
 
@@ -78,7 +99,6 @@ describe("checkOauthDiscovery — oracle fixtures", () => {
       expect(result.evidence).toHaveLength(oracle.evidence.length);
 
       // Both well-known paths must always be probed regardless of order.
-      const origin = new URL(oracle.url).origin;
       expect(calls).toEqual(
         expect.arrayContaining([
           `${origin}/.well-known/oauth-authorization-server`,

--- a/tests/engine/oauth-discovery.spec.ts
+++ b/tests/engine/oauth-discovery.spec.ts
@@ -105,6 +105,21 @@ describe("checkOauthDiscovery — oracle fixtures", () => {
         "conclude",
       );
 
+      // On the 5-step pass path (vercel) pin the middle-of-evidence order so
+      // the per-endpoint grouping (fetch → validate adjacency) we guarantee
+      // is locked in, not just the terminals.
+      if (result.evidence.length === 5) {
+        expect(result.evidence[1]!.label).toBe(
+          "Validate oauth-authorization-server structure",
+        );
+        expect(result.evidence[2]!.label).toBe(
+          "GET /.well-known/openid-configuration",
+        );
+        expect(result.evidence[3]!.label).toBe(
+          "Validate openid-configuration structure",
+        );
+      }
+
       // Per-fixture details parity (when the oracle has them).
       if (oracle.details?.grantTypes !== undefined) {
         expect(result.details?.grantTypes).toEqual(oracle.details.grantTypes);
@@ -302,6 +317,47 @@ describe("checkOauthDiscovery — edge cases", () => {
       "GET /.well-known/oauth-authorization-server",
     );
     expect(result.evidence[1]!.label).toBe(
+      "GET /.well-known/openid-configuration",
+    );
+  });
+
+  it("preserves dispatch order when the delayed endpoint is the one that passes", async () => {
+    // The delayed endpoint (oauth-authorization-server) returns 200 JSON; the
+    // fast endpoint (openid-configuration) returns 404. Evidence must still
+    // emit fetch+validate for oauth-authorization-server BEFORE the 404 fetch
+    // for openid-configuration — proving dispatch ordering even when the
+    // evidence stream interleaves fetch+validate steps.
+    const fetchImpl: typeof fetch = async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      if (url.endsWith("/oauth-authorization-server")) {
+        await new Promise((r) => setTimeout(r, 20));
+        return new Response(
+          JSON.stringify({
+            issuer: "https://example.com",
+            authorization_endpoint: "https://example.com/oauth/authorize",
+            token_endpoint: "https://example.com/oauth/token",
+            jwks_uri: "https://example.com/.well-known/jwks",
+          }),
+          { status: 200, headers: JSON_HEADERS },
+        );
+      }
+      return new Response("", { status: 404 });
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.evidence[0]!.label).toBe(
+      "GET /.well-known/oauth-authorization-server",
+    );
+    expect(result.evidence[1]!.label).toBe(
+      "Validate oauth-authorization-server structure",
+    );
+    expect(result.evidence[2]!.label).toBe(
       "GET /.well-known/openid-configuration",
     );
   });

--- a/tests/engine/oauth-discovery.spec.ts
+++ b/tests/engine/oauth-discovery.spec.ts
@@ -12,20 +12,23 @@
  *   - cf-dev / cf / example / shopify: both 404 → status "fail", 3 steps
  *     (fetch + fetch + conclude).
  *
- * Oracle evidence ordering varies across fixtures (some probe oauth-auth-server
- * first, others probe openid-configuration first). We normalise by checking
- * the set of labels rather than sequence, while still asserting length and
- * finding outcomes.
+ * SYNTHESISED BODY (vercel) — the vercel oracle preserves response headers
+ * but not `bodyPreview` for its OAuth/OIDC metadata endpoints. We reconstruct
+ * a minimal valid payload from the oracle's own `details` fields so the
+ * validator accepts it; one edge case below also feeds a captured real-world
+ * Vercel payload through the check to assert full `details` parity without
+ * synthesis.
  */
 
 import { describe, expect, it } from "vitest";
 
 import {
   ALL_SITES,
-  loadOracle,
+  expectCheckMatchesOracle,
   makeFetchStub,
-  type OracleSite,
-  type StubHandler,
+  runCheckAgainstOracle,
+  type OracleCheckLike,
+  type OracleStepLike,
 } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
@@ -36,69 +39,57 @@ import { checkOauthDiscovery } from "@/lib/engine/checks/oauth-discovery";
 // Oracle round-trip
 // ---------------------------------------------------------------------------
 
-function getOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return oracle.raw.checks.discovery.oauthDiscovery as any;
+function getOracleEntry(raw: unknown): OracleCheckLike {
+  return (raw as { checks: { discovery: { oauthDiscovery: OracleCheckLike } } })
+    .checks.discovery.oauthDiscovery;
 }
 
-async function runAgainstOracle(site: OracleSite) {
-  const loaded = loadOracle(site);
-  const check = getOracle(site);
-
-  const routes: Record<string, StubHandler> = {};
-  for (const step of check.evidence) {
-    if (step.action !== "fetch" || !step.request || !step.response) continue;
-    // When the oracle advertises a 200 JSON response but did not preserve the
-    // body (Cloudflare often truncates these out), synthesize a minimal valid
-    // OAuth/OIDC metadata document that also carries the oracle's declared
-    // `issuer` and other `details` fields so the validator passes.
-    let body = step.response.bodyPreview ?? "";
-    const contentType = (step.response.headers?.["content-type"] ?? "").toLowerCase();
-    if (
-      step.response.status === 200 &&
-      contentType.includes("application/json") &&
-      body === ""
-    ) {
-      body = JSON.stringify({
-        issuer: check.details?.issuer ?? loaded.origin,
-        authorization_endpoint: `${loaded.origin}/oauth/authorize`,
-        token_endpoint: `${loaded.origin}/oauth/token`,
-        jwks_uri: `${loaded.origin}/.well-known/jwks`,
-        ...(Array.isArray(check.details?.grantTypes)
-          ? { grant_types_supported: check.details.grantTypes }
-          : {}),
-      });
-    }
-    routes[step.request.url] = {
-      status: step.response.status,
-      statusText: step.response.statusText,
-      headers: step.response.headers ?? {},
-      body,
-    };
+function synthesiseBody(
+  step: OracleStepLike,
+  oracle: OracleCheckLike,
+): string | undefined {
+  if (step.response === undefined) return undefined;
+  const ct = (step.response.headers?.["content-type"] ?? "").toLowerCase();
+  if (step.response.status !== 200 || !ct.includes("application/json")) {
+    return undefined;
   }
-
-  const stub = makeFetchStub(routes);
-  const ctx = createScanContext({
-    url: loaded.url,
-    fetchImpl: stub.fetchImpl,
+  // Reconstruct JSON whose `validateMetadata` output matches the oracle's
+  // recorded `details`. Without this the Cloudflare-truncated 200 responses
+  // would fail validation during the round-trip.
+  const details = oracle.details ?? {};
+  const issuer =
+    typeof details.issuer === "string"
+      ? details.issuer
+      : new URL(step.request!.url).origin;
+  const grantTypes = Array.isArray(details.grantTypes)
+    ? details.grantTypes
+    : undefined;
+  return JSON.stringify({
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    jwks_uri: `${issuer}/.well-known/jwks`,
+    ...(grantTypes !== undefined ? { grant_types_supported: grantTypes } : {}),
   });
-  const result = await checkOauthDiscovery(ctx);
-  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
 }
 
 describe("checkOauthDiscovery — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, origin, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runCheckAgainstOracle({
+        site,
+        getOracleEntry,
+        runCheck: checkOauthDiscovery,
+        synthesiseBody,
+      });
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
+      // Dispatch order differs from oracle capture order on some fixtures
+      // (vercel captured OIDC first; we dispatch oauth-authorization-server
+      // first). Compare by label so the assertion is order-agnostic.
+      expectCheckMatchesOracle(result, oracle, { evidenceOrder: "by-label" });
 
-      expect(result.status).toBe(oracle.status);
-      expect(result.message).toBe(oracle.message);
-      expect(result.evidence).toHaveLength(oracle.evidence.length);
-
-      // Both well-known paths must always be probed regardless of order.
+      // Both well-known paths must always be probed.
       expect(calls).toEqual(
         expect.arrayContaining([
           `${origin}/.well-known/oauth-authorization-server`,
@@ -106,20 +97,26 @@ describe("checkOauthDiscovery — oracle fixtures", () => {
         ]),
       );
 
-      // Terminal step is the Conclusion.
-      const last = result.evidence[result.evidence.length - 1]!;
-      expect(last.action).toBe("conclude");
-      expect(last.label).toBe("Conclusion");
-      expect(last.finding.outcome).toBe(
-        oracle.evidence[oracle.evidence.length - 1].finding.outcome,
+      // Dispatch order is deterministic: oauth-authorization-server first.
+      expect(result.evidence[0]!.label).toBe(
+        "GET /.well-known/oauth-authorization-server",
+      );
+      expect(result.evidence[result.evidence.length - 1]!.action).toBe(
+        "conclude",
       );
 
-      // The set of labels should match the oracle's set (order-independent).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const oracleLabels = oracle.evidence.map((s: any) => s.label).sort();
-      const actualLabels = result.evidence.map((s) => s.label).sort();
-      expect(actualLabels).toEqual(oracleLabels);
-
+      // Per-fixture details parity (when the oracle has them).
+      if (oracle.details?.grantTypes !== undefined) {
+        expect(result.details?.grantTypes).toEqual(oracle.details.grantTypes);
+      }
+      if (oracle.details?.hasTokenEndpoint !== undefined) {
+        expect(result.details?.hasTokenEndpoint).toBe(
+          oracle.details.hasTokenEndpoint,
+        );
+      }
+      if (oracle.details?.hasJwksUri !== undefined) {
+        expect(result.details?.hasJwksUri).toBe(oracle.details.hasJwksUri);
+      }
       if (oracle.details?.source !== undefined) {
         expect(result.details?.source).toBe(oracle.details.source);
       }
@@ -136,7 +133,80 @@ describe("checkOauthDiscovery — oracle fixtures", () => {
 
 const JSON_HEADERS = { "content-type": "application/json" };
 
+/**
+ * Real-world Vercel OpenID Connect metadata captured via
+ *   `curl -s https://vercel.com/.well-known/openid-configuration`
+ * in April 2026. Kept here (not in the shared fixture) to avoid cross-worktree
+ * churn, while still feeding the check a non-synthesised payload end-to-end.
+ */
+const VERCEL_OIDC_BODY = JSON.stringify({
+  issuer: "https://vercel.com",
+  jwks_uri: "https://vercel.com/.well-known/jwks",
+  authorization_endpoint: "https://vercel.com/oauth/authorize",
+  token_endpoint: "https://api.vercel.com/login/oauth/token",
+  userinfo_endpoint: "https://api.vercel.com/login/oauth/userinfo",
+  grant_types_supported: [
+    "authorization_code",
+    "client_credentials",
+    "refresh_token",
+    "urn:ietf:params:oauth:grant-type:device_code",
+  ],
+});
+
 describe("checkOauthDiscovery — edge cases", () => {
+  it("asserts full details parity when fed a real Vercel OIDC payload", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://vercel.com/.well-known/oauth-authorization-server": {
+        status: 404,
+        headers: {},
+      },
+      "https://vercel.com/.well-known/openid-configuration": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: VERCEL_OIDC_BODY,
+      },
+    });
+    const ctx = createScanContext({ url: "https://vercel.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+
+    expect(result.status).toBe("pass");
+    expect(result.details?.source).toBe("openid-configuration");
+    expect(result.details?.issuer).toBe("https://vercel.com");
+    expect(result.details?.hasAuthorizationEndpoint).toBe(true);
+    expect(result.details?.hasTokenEndpoint).toBe(true);
+    expect(result.details?.hasJwksUri).toBe(true);
+    expect(result.details?.grantTypes).toEqual([
+      "authorization_code",
+      "client_credentials",
+      "refresh_token",
+      "urn:ietf:params:oauth:grant-type:device_code",
+    ]);
+  });
+
+  it("passes via oauth-authorization-server fallback when only that endpoint responds", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/oauth-authorization-server": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          issuer: "https://example.com",
+          authorization_endpoint: "https://example.com/oauth/authorize",
+          token_endpoint: "https://example.com/oauth/token",
+          jwks_uri: "https://example.com/.well-known/jwks",
+        }),
+      },
+      "https://example.com/.well-known/openid-configuration": {
+        status: 404,
+        headers: { "content-type": "text/plain" },
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.details?.source).toBe("oauth-authorization-server");
+    expect(result.message).toBe("OAuth authorization server metadata found");
+  });
+
   it("passes when only openid-configuration responds", async () => {
     const { fetchImpl } = makeFetchStub({
       "https://example.com/.well-known/oauth-authorization-server": {
@@ -157,6 +227,7 @@ describe("checkOauthDiscovery — edge cases", () => {
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkOauthDiscovery(ctx);
     expect(result.status).toBe("pass");
+    expect(result.details?.source).toBe("openid-configuration");
   });
 
   it("fails when both endpoints return 404", async () => {
@@ -209,5 +280,29 @@ describe("checkOauthDiscovery — edge cases", () => {
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkOauthDiscovery(ctx);
     expect(result.status).toBe("fail");
+  });
+
+  it("preserves dispatch order (oauth-authorization-server first) regardless of resolution timing", async () => {
+    // Delay oauth-authorization-server so openid-configuration resolves first.
+    const fetchImpl: typeof fetch = async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      if (url.endsWith("/oauth-authorization-server")) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      return new Response("", { status: 404 });
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthDiscovery(ctx);
+    expect(result.evidence[0]!.label).toBe(
+      "GET /.well-known/oauth-authorization-server",
+    );
+    expect(result.evidence[1]!.label).toBe(
+      "GET /.well-known/openid-configuration",
+    );
   });
 });

--- a/tests/engine/oauth-protected-resource.spec.ts
+++ b/tests/engine/oauth-protected-resource.spec.ts
@@ -37,7 +37,7 @@ function getOracle(site: OracleSite) {
 }
 
 async function runAgainstOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
+  const loaded = loadOracle(site);
   const check = getOracle(site);
 
   const routes: Record<string, StubHandler> = {};
@@ -53,24 +53,23 @@ async function runAgainstOracle(site: OracleSite) {
   // The homepage URL in the oracle is recorded without trailing slash
   // (e.g. "https://example.com") but ctx.fetch("/") produces
   // "https://example.com/". Register both forms to keep the stub happy.
-  const origin = new URL(oracle.url).origin;
-  if (routes[origin] !== undefined) {
-    routes[`${origin}/`] = routes[origin];
+  if (routes[loaded.origin] !== undefined) {
+    routes[`${loaded.origin}/`] = routes[loaded.origin];
   }
 
   const stub = makeFetchStub(routes);
   const ctx = createScanContext({
-    url: oracle.url,
+    url: loaded.url,
     fetchImpl: stub.fetchImpl,
   });
   const result = await checkOauthProtectedResource(ctx);
-  return { result, oracle: check, calls: stub.calls };
+  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
 }
 
 describe("checkOauthProtectedResource — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runAgainstOracle(site);
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
 
@@ -78,8 +77,6 @@ describe("checkOauthProtectedResource — oracle fixtures", () => {
       expect(result.message).toBe(oracle.message);
       expect(result.evidence).toHaveLength(oracle.evidence.length);
 
-      // Both paths probed.
-      const origin = new URL(oracle.url).origin;
       // Homepage call may come in as either origin or origin/ — tolerate both.
       const sawHomepage = calls.some(
         (c) => c === origin || c === `${origin}/`,
@@ -162,6 +159,47 @@ describe("checkOauthProtectedResource — edge cases", () => {
     const fetchImpl: typeof fetch = async () => {
       throw new Error("ECONNRESET");
     };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthProtectedResource(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("records a positive homepage finding when WWW-Authenticate is present", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/": {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: {
+          "www-authenticate": 'Bearer resource="https://example.com"',
+        },
+      },
+      "https://example.com/.well-known/oauth-protected-resource": {
+        status: 404,
+        headers: {},
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthProtectedResource(ctx);
+    // Still fails (well-known 404); but homepage step must be positive.
+    expect(result.status).toBe("fail");
+    const homepageStep = result.evidence.find(
+      (s) => s.action === "fetch" && s.label === "GET /",
+    );
+    expect(homepageStep?.finding.outcome).toBe("positive");
+  });
+
+  it("fails when well-known returns 200 but not JSON", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/": {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      },
+      "https://example.com/.well-known/oauth-protected-resource": {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: "<html></html>",
+      },
+    });
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkOauthProtectedResource(ctx);
     expect(result.status).toBe("fail");

--- a/tests/engine/oauth-protected-resource.spec.ts
+++ b/tests/engine/oauth-protected-resource.spec.ts
@@ -8,18 +8,20 @@
  *
  * Oracle observations across 5 fixtures (all 5 fail):
  *   - 3 evidence steps in each: homepage fetch + well-known fetch + conclude.
- *   - Order varies per fixture (shopify probes well-known first, cf-dev
- *     homepage first). We tolerate both.
+ *   - The oracle captures resolution order which varies per fixture. Our
+ *     implementation now emits in fixed DISPATCH order (homepage then
+ *     well-known), so we compare by label (order-independent for non-terminal
+ *     steps) and still assert the conclusion is last.
  */
 
 import { describe, expect, it } from "vitest";
 
 import {
   ALL_SITES,
-  loadOracle,
+  expectCheckMatchesOracle,
   makeFetchStub,
-  type OracleSite,
-  type StubHandler,
+  runCheckAgainstOracle,
+  type OracleCheckLike,
 } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
@@ -30,67 +32,39 @@ import { checkOauthProtectedResource } from "@/lib/engine/checks/oauth-protected
 // Oracle round-trip
 // ---------------------------------------------------------------------------
 
-function getOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return oracle.raw.checks.discovery.oauthProtectedResource as any;
-}
-
-async function runAgainstOracle(site: OracleSite) {
-  const loaded = loadOracle(site);
-  const check = getOracle(site);
-
-  const routes: Record<string, StubHandler> = {};
-  for (const step of check.evidence) {
-    if (step.action !== "fetch" || !step.request || !step.response) continue;
-    routes[step.request.url] = {
-      status: step.response.status,
-      statusText: step.response.statusText,
-      headers: step.response.headers ?? {},
-      body: step.response.bodyPreview ?? "",
-    };
-  }
-  // The homepage URL in the oracle is recorded without trailing slash
-  // (e.g. "https://example.com") but ctx.fetch("/") produces
-  // "https://example.com/". Register both forms to keep the stub happy.
-  if (routes[loaded.origin] !== undefined) {
-    routes[`${loaded.origin}/`] = routes[loaded.origin];
-  }
-
-  const stub = makeFetchStub(routes);
-  const ctx = createScanContext({
-    url: loaded.url,
-    fetchImpl: stub.fetchImpl,
-  });
-  const result = await checkOauthProtectedResource(ctx);
-  return { result, oracle: check, origin: loaded.origin, calls: stub.calls };
+function getOracleEntry(raw: unknown): OracleCheckLike {
+  return (
+    raw as {
+      checks: { discovery: { oauthProtectedResource: OracleCheckLike } };
+    }
+  ).checks.discovery.oauthProtectedResource;
 }
 
 describe("checkOauthProtectedResource — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle, origin, calls } = await runAgainstOracle(site);
+      const { result, oracle, origin, calls } = await runCheckAgainstOracle({
+        site,
+        getOracleEntry,
+        runCheck: checkOauthProtectedResource,
+      });
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
+      expectCheckMatchesOracle(result, oracle, { evidenceOrder: "by-label" });
 
-      expect(result.status).toBe(oracle.status);
-      expect(result.message).toBe(oracle.message);
-      expect(result.evidence).toHaveLength(oracle.evidence.length);
-
-      // Homepage call may come in as either origin or origin/ — tolerate both.
-      const sawHomepage = calls.some(
-        (c) => c === origin || c === `${origin}/`,
+      // Dispatch order: homepage first, well-known second.
+      expect(result.evidence[0]!.label).toBe("GET /");
+      expect(result.evidence[1]!.label).toBe(
+        "GET /.well-known/oauth-protected-resource",
       );
-      expect(sawHomepage).toBe(true);
+      expect(result.evidence[2]!.action).toBe("conclude");
+
       expect(calls).toEqual(
         expect.arrayContaining([
+          `${origin}/`,
           `${origin}/.well-known/oauth-protected-resource`,
         ]),
       );
-
-      const last = result.evidence[result.evidence.length - 1]!;
-      expect(last.action).toBe("conclude");
-      expect(last.label).toBe("Conclusion");
     });
   }
 });
@@ -203,5 +177,29 @@ describe("checkOauthProtectedResource — edge cases", () => {
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkOauthProtectedResource(ctx);
     expect(result.status).toBe("fail");
+  });
+
+  it("preserves dispatch order (homepage, then well-known) even when well-known resolves first", async () => {
+    // Delay homepage so well-known resolves first; evidence must still reflect
+    // dispatch order (homepage at index 0).
+    const fetchImpl: typeof fetch = async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      if (url === "https://example.com/") {
+        await new Promise((r) => setTimeout(r, 20));
+        return new Response("", { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthProtectedResource(ctx);
+    expect(result.evidence[0]!.label).toBe("GET /");
+    expect(result.evidence[1]!.label).toBe(
+      "GET /.well-known/oauth-protected-resource",
+    );
   });
 });

--- a/tests/engine/oauth-protected-resource.spec.ts
+++ b/tests/engine/oauth-protected-resource.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Oracle-driven tests for checkOauthProtectedResource.
+ *
+ * Spec (FINDINGS §3 / §9):
+ *   Probe: GET /              (to sniff WWW-Authenticate)
+ *          GET /.well-known/oauth-protected-resource
+ *   Pass: 200 JSON with a `resource` field.
+ *
+ * Oracle observations across 5 fixtures (all 5 fail):
+ *   - 3 evidence steps in each: homepage fetch + well-known fetch + conclude.
+ *   - Order varies per fixture (shopify probes well-known first, cf-dev
+ *     homepage first). We tolerate both.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ALL_SITES,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+  type StubHandler,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+
+import { checkOauthProtectedResource } from "@/lib/engine/checks/oauth-protected-resource";
+
+// ---------------------------------------------------------------------------
+// Oracle round-trip
+// ---------------------------------------------------------------------------
+
+function getOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return oracle.raw.checks.discovery.oauthProtectedResource as any;
+}
+
+async function runAgainstOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  const check = getOracle(site);
+
+  const routes: Record<string, StubHandler> = {};
+  for (const step of check.evidence) {
+    if (step.action !== "fetch" || !step.request || !step.response) continue;
+    routes[step.request.url] = {
+      status: step.response.status,
+      statusText: step.response.statusText,
+      headers: step.response.headers ?? {},
+      body: step.response.bodyPreview ?? "",
+    };
+  }
+  // The homepage URL in the oracle is recorded without trailing slash
+  // (e.g. "https://example.com") but ctx.fetch("/") produces
+  // "https://example.com/". Register both forms to keep the stub happy.
+  const origin = new URL(oracle.url).origin;
+  if (routes[origin] !== undefined) {
+    routes[`${origin}/`] = routes[origin];
+  }
+
+  const stub = makeFetchStub(routes);
+  const ctx = createScanContext({
+    url: oracle.url,
+    fetchImpl: stub.fetchImpl,
+  });
+  const result = await checkOauthProtectedResource(ctx);
+  return { result, oracle: check, calls: stub.calls };
+}
+
+describe("checkOauthProtectedResource — oracle fixtures", () => {
+  for (const site of ALL_SITES) {
+    it(`matches the ${site} oracle`, async () => {
+      const { result, oracle, calls } = await runAgainstOracle(site);
+
+      expect(() => CheckResultSchema.parse(result)).not.toThrow();
+
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+      expect(result.evidence).toHaveLength(oracle.evidence.length);
+
+      // Both paths probed.
+      const origin = new URL(oracle.url).origin;
+      // Homepage call may come in as either origin or origin/ — tolerate both.
+      const sawHomepage = calls.some(
+        (c) => c === origin || c === `${origin}/`,
+      );
+      expect(sawHomepage).toBe(true);
+      expect(calls).toEqual(
+        expect.arrayContaining([
+          `${origin}/.well-known/oauth-protected-resource`,
+        ]),
+      );
+
+      const last = result.evidence[result.evidence.length - 1]!;
+      expect(last.action).toBe("conclude");
+      expect(last.label).toBe("Conclusion");
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+describe("checkOauthProtectedResource — edge cases", () => {
+  it("passes when well-known returns 200 JSON with `resource` field", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/": {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      },
+      "https://example.com/.well-known/oauth-protected-resource": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          resource: "https://example.com",
+          authorization_servers: ["https://auth.example.com"],
+        }),
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthProtectedResource(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when well-known returns 200 JSON but no `resource` field", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/": {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      },
+      "https://example.com/.well-known/oauth-protected-resource": {
+        status: 200,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ foo: "bar" }),
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthProtectedResource(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when well-known returns 404", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/": {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      },
+      "https://example.com/.well-known/oauth-protected-resource": {
+        status: 404,
+        headers: {},
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthProtectedResource(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails gracefully on transport errors to well-known", async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new Error("ECONNRESET");
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkOauthProtectedResource(ctx);
+    expect(result.status).toBe("fail");
+  });
+});

--- a/tests/engine/oauth-protected-resource.spec.ts
+++ b/tests/engine/oauth-protected-resource.spec.ts
@@ -130,12 +130,32 @@ describe("checkOauthProtectedResource — edge cases", () => {
   });
 
   it("fails gracefully on transport errors to well-known", async () => {
-    const fetchImpl: typeof fetch = async () => {
-      throw new Error("ECONNRESET");
+    const fetchImpl: typeof fetch = async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      if (url.includes("/.well-known/oauth-protected-resource")) {
+        throw new Error("ECONNRESET");
+      }
+      // Homepage (and any other non-well-known request) returns a normal 200.
+      return new Response("", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
     };
     const ctx = createScanContext({ url: "https://example.com", fetchImpl });
     const result = await checkOauthProtectedResource(ctx);
     expect(result.status).toBe("fail");
+    // The well-known fetch must have failed (transport error).
+    const wellKnownStep = result.evidence.find(
+      (s) =>
+        s.action === "fetch" &&
+        s.label === "GET /.well-known/oauth-protected-resource",
+    );
+    expect(wellKnownStep?.finding.outcome).toBe("negative");
   });
 
   it("records a positive homepage finding when WWW-Authenticate is present", async () => {

--- a/tests/engine/web-bot-auth.spec.ts
+++ b/tests/engine/web-bot-auth.spec.ts
@@ -20,76 +20,36 @@ import { describe, expect, it } from "vitest";
 
 import {
   ALL_SITES,
-  loadOracle,
+  expectCheckMatchesOracle,
   makeFetchStub,
-  type OracleSite,
-  type StubHandler,
+  runCheckAgainstOracle,
+  type OracleCheckLike,
 } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
 
-// Not-yet-implemented (module should not resolve until GREEN phase).
 import { checkWebBotAuth } from "@/lib/engine/checks/web-bot-auth";
 
 // ---------------------------------------------------------------------------
 // Oracle round-trip
 // ---------------------------------------------------------------------------
 
-function getOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return oracle.raw.checks.botAccessControl.webBotAuth as any;
-}
-
-async function runAgainstOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
-  const check = getOracle(site);
-
-  const routes: Record<string, StubHandler> = {};
-  for (const step of check.evidence) {
-    if (step.action !== "fetch" || !step.request || !step.response) continue;
-    routes[step.request.url] = {
-      status: step.response.status,
-      statusText: step.response.statusText,
-      headers: step.response.headers ?? {},
-      body: step.response.bodyPreview ?? "",
-    };
-  }
-
-  const stub = makeFetchStub(routes);
-  const ctx = createScanContext({
-    url: oracle.url,
-    fetchImpl: stub.fetchImpl,
-  });
-  const result = await checkWebBotAuth(ctx);
-  return { result, oracle: check, calls: stub.calls };
+function getOracleEntry(raw: unknown): OracleCheckLike {
+  return (raw as { checks: { botAccessControl: { webBotAuth: OracleCheckLike } } })
+    .checks.botAccessControl.webBotAuth;
 }
 
 describe("checkWebBotAuth — oracle fixtures", () => {
   for (const site of ALL_SITES) {
     it(`matches the ${site} oracle`, async () => {
-      const { result, oracle } = await runAgainstOracle(site);
+      const { result, oracle } = await runCheckAgainstOracle({
+        site,
+        getOracleEntry,
+        runCheck: checkWebBotAuth,
+      });
 
       expect(() => CheckResultSchema.parse(result)).not.toThrow();
-
-      expect(result.status).toBe(oracle.status);
-      expect(result.message).toBe(oracle.message);
-      expect(result.evidence).toHaveLength(oracle.evidence.length);
-
-      for (let i = 0; i < oracle.evidence.length; i++) {
-        const want = oracle.evidence[i];
-        const got = result.evidence[i]!;
-        expect(got.action, `evidence[${i}].action`).toBe(want.action);
-        expect(got.label, `evidence[${i}].label`).toBe(want.label);
-        // Oracle may omit the `finding` field on neutral fetch steps
-        // (shopify fixture); our implementation always emits one. Only
-        // assert parity when the oracle recorded a finding.
-        if (want.finding !== undefined) {
-          expect(got.finding.outcome, `evidence[${i}].finding.outcome`).toBe(
-            want.finding.outcome,
-          );
-        }
-      }
+      expectCheckMatchesOracle(result, oracle);
     });
   }
 });

--- a/tests/engine/web-bot-auth.spec.ts
+++ b/tests/engine/web-bot-auth.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Oracle-driven tests for checkWebBotAuth.
+ *
+ * Spec (FINDINGS §3 / §9):
+ *   Probe: GET /.well-known/http-message-signatures-directory
+ *   Pass: 200 + JSON body with a non-empty `keys` array (RFC 7517 JWKS shape).
+ *   Otherwise: NEUTRAL (informational). The check is never a hard failure —
+ *   absence of Web Bot Auth is not grounds for denying agent-readiness.
+ *
+ * Oracle observations across 5 fixtures:
+ *   - cf-dev / cf / example / vercel: 404 → status="neutral", 2 evidence steps
+ *     (fetch + conclude) with `message` = "Web Bot Auth directory not found
+ *     (informational only)".
+ *   - shopify: 200 with a single JWK object (no `keys` wrapper) → status
+ *     still "neutral", 3 evidence steps (fetch + validate + conclude), message
+ *     says "missing required 'keys' array".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ALL_SITES,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+  type StubHandler,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+
+// Not-yet-implemented (module should not resolve until GREEN phase).
+import { checkWebBotAuth } from "@/lib/engine/checks/web-bot-auth";
+
+// ---------------------------------------------------------------------------
+// Oracle round-trip
+// ---------------------------------------------------------------------------
+
+function getOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return oracle.raw.checks.botAccessControl.webBotAuth as any;
+}
+
+async function runAgainstOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  const check = getOracle(site);
+
+  const routes: Record<string, StubHandler> = {};
+  for (const step of check.evidence) {
+    if (step.action !== "fetch" || !step.request || !step.response) continue;
+    routes[step.request.url] = {
+      status: step.response.status,
+      statusText: step.response.statusText,
+      headers: step.response.headers ?? {},
+      body: step.response.bodyPreview ?? "",
+    };
+  }
+
+  const stub = makeFetchStub(routes);
+  const ctx = createScanContext({
+    url: oracle.url,
+    fetchImpl: stub.fetchImpl,
+  });
+  const result = await checkWebBotAuth(ctx);
+  return { result, oracle: check, calls: stub.calls };
+}
+
+describe("checkWebBotAuth — oracle fixtures", () => {
+  for (const site of ALL_SITES) {
+    it(`matches the ${site} oracle`, async () => {
+      const { result, oracle } = await runAgainstOracle(site);
+
+      expect(() => CheckResultSchema.parse(result)).not.toThrow();
+
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+      expect(result.evidence).toHaveLength(oracle.evidence.length);
+
+      for (let i = 0; i < oracle.evidence.length; i++) {
+        const want = oracle.evidence[i];
+        const got = result.evidence[i]!;
+        expect(got.action, `evidence[${i}].action`).toBe(want.action);
+        expect(got.label, `evidence[${i}].label`).toBe(want.label);
+        expect(got.finding.outcome, `evidence[${i}].finding.outcome`).toBe(
+          want.finding.outcome,
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("checkWebBotAuth — edge cases", () => {
+  it("passes when a valid JWKS with non-empty keys[] is returned", async () => {
+    const jwks = {
+      keys: [
+        {
+          kty: "OKP",
+          crv: "Ed25519",
+          x: "abc",
+          use: "sig",
+          alg: "EdDSA",
+          kid: "k1",
+        },
+      ],
+    };
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/http-message-signatures-directory": {
+        status: 200,
+        headers: { "content-type": "application/jwk-set+json" },
+        body: JSON.stringify(jwks),
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkWebBotAuth(ctx);
+    expect(result.status).toBe("pass");
+    // Terminal step is a conclude with positive outcome.
+    const last = result.evidence[result.evidence.length - 1]!;
+    expect(last.action).toBe("conclude");
+    expect(last.finding.outcome).toBe("positive");
+  });
+
+  it("stays neutral when the directory is missing (404)", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/http-message-signatures-directory": {
+        status: 404,
+        headers: { "content-type": "text/html" },
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkWebBotAuth(ctx);
+    expect(result.status).toBe("neutral");
+  });
+
+  it("stays neutral on transport errors", async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new Error("ENOTFOUND");
+    };
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkWebBotAuth(ctx);
+    expect(result.status).toBe("neutral");
+  });
+
+  it("stays neutral when the body is not valid JSON (informational)", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://example.com/.well-known/http-message-signatures-directory": {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: "<html>oops</html>",
+      },
+    });
+    const ctx = createScanContext({ url: "https://example.com", fetchImpl });
+    const result = await checkWebBotAuth(ctx);
+    expect(result.status).toBe("neutral");
+  });
+});

--- a/tests/engine/web-bot-auth.spec.ts
+++ b/tests/engine/web-bot-auth.spec.ts
@@ -81,9 +81,14 @@ describe("checkWebBotAuth — oracle fixtures", () => {
         const got = result.evidence[i]!;
         expect(got.action, `evidence[${i}].action`).toBe(want.action);
         expect(got.label, `evidence[${i}].label`).toBe(want.label);
-        expect(got.finding.outcome, `evidence[${i}].finding.outcome`).toBe(
-          want.finding.outcome,
-        );
+        // Oracle may omit the `finding` field on neutral fetch steps
+        // (shopify fixture); our implementation always emits one. Only
+        // assert parity when the oracle recorded a finding.
+        if (want.finding !== undefined) {
+          expect(got.finding.outcome, `evidence[${i}].finding.outcome`).toBe(
+            want.finding.outcome,
+          );
+        }
       }
     });
   }


### PR DESCRIPTION
Tracks task #4. Owned: impl-C. Files: lib/engine/checks/{web-bot-auth,oauth-discovery,oauth-protected-resource,api-catalog,mcp-server-card}.ts + specs. TDD workflow: RED specs first, then impl, then 3 review iterations before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API Catalog discovery check to detect API catalog endpoints.
  * Added MCP Server discovery check to identify MCP server configurations.
  * Added OAuth/OIDC discovery check to find OAuth and OpenID Connect metadata endpoints.
  * Added OAuth Protected Resource discovery check to locate protected resource configurations.
  * Added informational bot access control check for HTTP Message Signatures authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->