### PR TITLE
Phase 2 — agent discovery + webmcp checks (a2aAgentCard, agentSkills, webMcp)

### DIFF
--- a/lib/engine/checks/a2a-agent-card.ts
+++ b/lib/engine/checks/a2a-agent-card.ts
@@ -1,0 +1,195 @@
+/**
+ * Discovery check: `a2aAgentCard`.
+ *
+ * Specification
+ * -------------
+ * - GET `/.well-known/agent-card.json` on the origin.
+ * - Pass iff the response is 200 AND the body parses as JSON AND contains at
+ *   least `{ name: string, version: string, skills: [non-empty array] }` per
+ *   FINDINGS §3 and the task specification.
+ * - Fail on 404, transport error, non-JSON body, missing required fields,
+ *   or an empty skills array.
+ *
+ * NOTE: this check is reported regardless of the user's enabledChecks opt-in
+ * status — the scoring layer is responsible for excluding it from the
+ * denominator when the user hasn't opted in. FINDINGS §13 pt. 4.
+ *
+ * Evidence timeline
+ * -----------------
+ * - Fail (404 / transport): fetch -> conclude.
+ * - Fail (invalid JSON): fetch -> validate (JSON parse) -> conclude.
+ * - Fail (missing fields): fetch -> validate (JSON parse) -> validate (shape) -> conclude.
+ * - Pass:                  fetch -> validate (JSON parse) -> validate (shape) -> conclude.
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type FetchOutcome,
+  type ScanContext,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AGENT_CARD_PATH = "/.well-known/agent-card.json";
+const FETCH_LABEL = "GET /.well-known/agent-card.json";
+const PARSE_JSON_LABEL = "Parse agent-card.json";
+const VALIDATE_SHAPE_LABEL = "Validate A2A agent card shape";
+const CONCLUDE_LABEL = "Conclusion";
+
+const FAIL_NOT_FOUND_MESSAGE = "A2A Agent Card not found";
+const FAIL_INVALID_JSON_MESSAGE = "A2A Agent Card is not valid JSON";
+const FAIL_INVALID_SHAPE_MESSAGE =
+  "A2A Agent Card is missing required fields (name, version, skills)";
+const PASS_MESSAGE = "A2A Agent Card is valid";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface AgentCardShape {
+  readonly name: string;
+  readonly version: string;
+  readonly skills: readonly unknown[];
+}
+
+function hasValidCardShape(value: unknown): value is AgentCardShape {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.name !== "string" || obj.name.length === 0) return false;
+  if (typeof obj.version !== "string" || obj.version.length === 0) return false;
+  if (!Array.isArray(obj.skills) || obj.skills.length === 0) return false;
+  return true;
+}
+
+function buildFetchFailStep(outcome: FetchOutcome): EvidenceStep {
+  if (outcome.response === undefined) {
+    return fetchToStep(outcome, FETCH_LABEL, {
+      outcome: "negative",
+      summary: outcome.error
+        ? `Transport error fetching agent-card.json: ${outcome.error}`
+        : "Transport error fetching agent-card.json",
+    });
+  }
+  return fetchToStep(outcome, FETCH_LABEL, {
+    outcome: "negative",
+    summary: `Server returned ${outcome.response.status} -- A2A Agent Card not found`,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkA2aAgentCard(
+  ctx: ScanContext,
+): Promise<CheckResult> {
+  const started = Date.now();
+  const outcome = await ctx.fetch(AGENT_CARD_PATH);
+
+  // 1. Fetch failure or non-200 response.
+  if (outcome.response === undefined || outcome.response.status !== 200) {
+    const evidence: EvidenceStep[] = [
+      buildFetchFailStep(outcome),
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_NOT_FOUND_MESSAGE,
+      }),
+    ];
+    return {
+      status: "fail",
+      message: FAIL_NOT_FOUND_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  // 2. Attempt to parse JSON body.
+  const fetchStep = fetchToStep(outcome, FETCH_LABEL, {
+    outcome: "positive",
+    summary: `Received 200 response with content-type: ${
+      outcome.response.headers["content-type"] ?? "unknown"
+    }`,
+  });
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(outcome.body ?? "");
+  } catch (err) {
+    const parseErr = err instanceof Error ? err.message : String(err);
+    const evidence: EvidenceStep[] = [
+      fetchStep,
+      makeStep("validate", PARSE_JSON_LABEL, {
+        outcome: "negative",
+        summary: `Failed to parse JSON body: ${parseErr}`,
+      }),
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_INVALID_JSON_MESSAGE,
+      }),
+    ];
+    return {
+      status: "fail",
+      message: FAIL_INVALID_JSON_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  // 3. Validate shape.
+  const parseStep = makeStep("validate", PARSE_JSON_LABEL, {
+    outcome: "positive",
+    summary: "agent-card.json parsed as valid JSON",
+  });
+
+  if (!hasValidCardShape(parsed)) {
+    const evidence: EvidenceStep[] = [
+      fetchStep,
+      parseStep,
+      makeStep("validate", VALIDATE_SHAPE_LABEL, {
+        outcome: "negative",
+        summary:
+          "Missing one or more required fields: name (string), version (string), skills (non-empty array)",
+      }),
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_INVALID_SHAPE_MESSAGE,
+      }),
+    ];
+    return {
+      status: "fail",
+      message: FAIL_INVALID_SHAPE_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  // 4. Pass.
+  const evidence: EvidenceStep[] = [
+    fetchStep,
+    parseStep,
+    makeStep("validate", VALIDATE_SHAPE_LABEL, {
+      outcome: "positive",
+      summary: `Card declares ${parsed.skills.length} skill(s)`,
+    }),
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "positive",
+      summary: PASS_MESSAGE,
+    }),
+  ];
+
+  return {
+    status: "pass",
+    message: PASS_MESSAGE,
+    details: {
+      name: parsed.name,
+      version: parsed.version,
+      skillCount: parsed.skills.length,
+    },
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}

--- a/lib/engine/checks/a2a-agent-card.ts
+++ b/lib/engine/checks/a2a-agent-card.ts
@@ -10,6 +10,12 @@
  * - Fail on 404, transport error, non-JSON body, missing required fields,
  *   or an empty skills array.
  *
+ * NOTE (FINDINGS §9 divergence): FINDINGS §9 phrases the pass predicate in
+ *   terms of `supportedInterfaces`. This implementation intentionally follows
+ *   FINDINGS §3 + the task brief + skill-a2a-agent-card.md and uses
+ *   `{ name, version, skills: non-empty[] }` as the pass predicate. Treat the
+ *   §9 wording as a doc bug — the skill/task contract is authoritative.
+ *
  * NOTE: this check is reported regardless of the user's enabledChecks opt-in
  * status — the scoring layer is responsible for excluding it from the
  * denominator when the user hasn't opted in. FINDINGS §13 pt. 4.

--- a/lib/engine/checks/agent-skills.ts
+++ b/lib/engine/checks/agent-skills.ts
@@ -82,12 +82,24 @@ function normaliseSkillEntries(skills: readonly unknown[]): SkillEntry[] {
   return out;
 }
 
-function extractSpecVersion(parsed: Record<string, unknown>): string | undefined {
+/** Legacy heuristic — matches the reference scanner (cf-dev fixture). */
+const LEGACY_SPEC_VERSION = "0.1.0";
+
+function extractSpecVersion(
+  parsed: Record<string, unknown>,
+  indexPath: string,
+): string | undefined {
   const schema = parsed.$schema;
-  if (typeof schema !== "string") return undefined;
-  // https://schemas.agentskills.io/discovery/0.2.0/schema.json
-  const match = /discovery\/(\d+\.\d+(?:\.\d+)?)\//.exec(schema);
-  return match?.[1];
+  if (typeof schema === "string") {
+    // https://schemas.agentskills.io/discovery/0.2.0/schema.json
+    const match = /discovery\/(\d+\.\d+(?:\.\d+)?)\//.exec(schema);
+    if (match?.[1] !== undefined) return match[1];
+  }
+  // Legacy fallback: when we hit /.well-known/skills/index.json and the body
+  // carries no $schema, the reference scanner reports specVersion "0.1.0"
+  // (see research/raw/scan-cf-dev.json). Mirror that behaviour.
+  if (indexPath === LEGACY_PATH) return LEGACY_SPEC_VERSION;
+  return undefined;
 }
 
 function skillDisplayName(skill: SkillEntry): string {
@@ -341,7 +353,7 @@ export async function checkAgentSkills(
     resolvedSkills: resolvedCount,
     path: indexPath,
   };
-  const specVersion = extractSpecVersion(indexObj);
+  const specVersion = extractSpecVersion(indexObj, indexPath);
   if (specVersion !== undefined) {
     details.specVersion = specVersion;
   }

--- a/lib/engine/checks/agent-skills.ts
+++ b/lib/engine/checks/agent-skills.ts
@@ -1,0 +1,356 @@
+/**
+ * Discovery check: `agentSkills`.
+ *
+ * Specification
+ * -------------
+ * - GET `/.well-known/agent-skills/index.json` (Agent Skills Discovery RFC
+ *   v0.2.0 path) on the origin.
+ * - On 404, fall back to the legacy `/.well-known/skills/index.json` path.
+ *   The reference scanner uses this same fallback — see
+ *   `research/raw/scan-cf-dev.json` for an oracle example.
+ * - Parse the JSON body. Expect a `skills: []` array; each entry may carry
+ *   `{ id | name, description, url | href }` per RFC v0.2.0 and the
+ *   FINDINGS §3 shorthand `{ id, name, href }`.
+ * - Resolve the first 3 skill hrefs (SKILL.md URLs). Pass iff the index is
+ *   valid JSON AND at least one skill URL responds 200 with a non-empty body.
+ *
+ * Evidence timeline (pass path):
+ *   fetch (index) -> validate (parse JSON) -> validate (count skills)
+ *     -> fetch (skill 1) [-> fetch (skill 2) [-> fetch (skill 3)]]
+ *     -> validate (resolution count) -> conclude
+ *
+ * Evidence timeline (fail path — no index on either path):
+ *   fetch (v0.2.0, neutral "trying legacy") -> fetch (legacy, negative 404)
+ *     -> conclude
+ *
+ * This fail shape matches the Cloudflare oracle fail fixtures exactly.
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type FetchOutcome,
+  type ScanContext,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const V0_2_PATH = "/.well-known/agent-skills/index.json";
+const LEGACY_PATH = "/.well-known/skills/index.json";
+
+const FETCH_V0_2_LABEL = "GET /.well-known/agent-skills/index.json";
+const FETCH_LEGACY_LABEL = "GET /.well-known/skills/index.json";
+const PARSE_JSON_LABEL = "Parse skills index";
+const COUNT_SKILLS_LABEL = "Count skills";
+const VALIDATE_RESOLUTION_LABEL = "Resolve skill references";
+const CONCLUDE_LABEL = "Conclusion";
+
+const FAIL_NOT_FOUND_MESSAGE = "Agent Skills index not found";
+const FAIL_INVALID_JSON_MESSAGE = "Agent Skills index is not valid JSON";
+const FAIL_NO_SKILLS_MESSAGE = "Agent Skills index does not declare any skills";
+const FAIL_NO_RESOLUTION_MESSAGE =
+  "Agent Skills index found but no referenced skills resolve";
+const PASS_MESSAGE = "Agent Skills index exists with valid JSON";
+
+/** Resolution cap — matches the task spec ("first 3 skill hrefs"). */
+const SKILL_RESOLUTION_LIMIT = 3;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SkillEntry {
+  readonly href: string;
+  readonly id?: string;
+  readonly name?: string;
+}
+
+function normaliseSkillEntries(skills: readonly unknown[]): SkillEntry[] {
+  const out: SkillEntry[] = [];
+  for (const entry of skills) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const obj = entry as Record<string, unknown>;
+    const hrefRaw = obj.href ?? obj.url;
+    if (typeof hrefRaw !== "string" || hrefRaw.length === 0) continue;
+    const id = typeof obj.id === "string" ? obj.id : undefined;
+    const name = typeof obj.name === "string" ? obj.name : undefined;
+    out.push({ href: hrefRaw, id, name });
+  }
+  return out;
+}
+
+function extractSpecVersion(parsed: Record<string, unknown>): string | undefined {
+  const schema = parsed.$schema;
+  if (typeof schema !== "string") return undefined;
+  // https://schemas.agentskills.io/discovery/0.2.0/schema.json
+  const match = /discovery\/(\d+\.\d+(?:\.\d+)?)\//.exec(schema);
+  return match?.[1];
+}
+
+function skillDisplayName(skill: SkillEntry): string {
+  return skill.id ?? skill.name ?? skill.href;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkAgentSkills(
+  ctx: ScanContext,
+): Promise<CheckResult> {
+  const started = Date.now();
+  const evidence: EvidenceStep[] = [];
+
+  // 1. Try the v0.2.0 path first.
+  const v0Outcome = await ctx.fetch(V0_2_PATH);
+  let indexOutcome: FetchOutcome | undefined;
+  let indexPath = V0_2_PATH;
+
+  if (v0Outcome.response?.status === 200) {
+    evidence.push(
+      fetchToStep(v0Outcome, FETCH_V0_2_LABEL, {
+        outcome: "positive",
+        summary: `Received 200 response with content-type: ${
+          v0Outcome.response.headers["content-type"] ?? "unknown"
+        }`,
+      }),
+    );
+    indexOutcome = v0Outcome;
+  } else {
+    // Record the v0.2.0 attempt as neutral ("trying legacy path") and fall
+    // back to the legacy path — matches the oracle's evidence shape.
+    evidence.push(
+      fetchToStep(v0Outcome, FETCH_V0_2_LABEL, {
+        outcome: "neutral",
+        summary: v0Outcome.response
+          ? `v0.2.0 path returned ${v0Outcome.response.status} — trying legacy path`
+          : `v0.2.0 path failed (${v0Outcome.error ?? "transport error"}) — trying legacy path`,
+      }),
+    );
+
+    const legacyOutcome = await ctx.fetch(LEGACY_PATH);
+    if (legacyOutcome.response?.status === 200) {
+      evidence.push(
+        fetchToStep(legacyOutcome, FETCH_LEGACY_LABEL, {
+          outcome: "positive",
+          summary: `Received 200 response with content-type: ${
+            legacyOutcome.response.headers["content-type"] ?? "unknown"
+          }`,
+        }),
+      );
+      indexOutcome = legacyOutcome;
+      indexPath = LEGACY_PATH;
+    } else {
+      evidence.push(
+        fetchToStep(legacyOutcome, FETCH_LEGACY_LABEL, {
+          outcome: "negative",
+          summary: legacyOutcome.response
+            ? `Server returned ${legacyOutcome.response.status} — Agent Skills index not found`
+            : `Transport error: ${legacyOutcome.error ?? "unknown"}`,
+        }),
+      );
+      evidence.push(
+        makeStep("conclude", CONCLUDE_LABEL, {
+          outcome: "negative",
+          summary: FAIL_NOT_FOUND_MESSAGE,
+        }),
+      );
+      return {
+        status: "fail",
+        message: FAIL_NOT_FOUND_MESSAGE,
+        evidence,
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  // 2. Parse the JSON body.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(indexOutcome.body ?? "");
+  } catch (err) {
+    const parseErr = err instanceof Error ? err.message : String(err);
+    evidence.push(
+      makeStep("validate", PARSE_JSON_LABEL, {
+        outcome: "negative",
+        summary: `Failed to parse JSON body: ${parseErr}`,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_INVALID_JSON_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_INVALID_JSON_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    evidence.push(
+      makeStep("validate", PARSE_JSON_LABEL, {
+        outcome: "negative",
+        summary: "Index root is not a JSON object",
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_INVALID_JSON_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_INVALID_JSON_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  const indexObj = parsed as Record<string, unknown>;
+  const rawSkills = Array.isArray(indexObj.skills) ? indexObj.skills : null;
+
+  if (rawSkills === null || rawSkills.length === 0) {
+    evidence.push(
+      makeStep("validate", COUNT_SKILLS_LABEL, {
+        outcome: "negative",
+        summary:
+          rawSkills === null
+            ? "Index JSON does not contain a 'skills' array"
+            : "Index 'skills' array is empty",
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_NO_SKILLS_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_NO_SKILLS_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  evidence.push(
+    makeStep("validate", COUNT_SKILLS_LABEL, {
+      outcome: "neutral",
+      summary: `Found "skills" array with ${rawSkills.length} entries`,
+    }),
+  );
+
+  // 3. Resolve up to the first N skill hrefs.
+  const skills = normaliseSkillEntries(rawSkills);
+  const toResolve = skills.slice(0, SKILL_RESOLUTION_LIMIT);
+  let resolvedCount = 0;
+
+  for (const skill of toResolve) {
+    let target: URL;
+    try {
+      target = ctx.resolve(skill.href);
+    } catch {
+      evidence.push(
+        makeStep(
+          "validate",
+          `Resolve skill ${skillDisplayName(skill)}`,
+          {
+            outcome: "negative",
+            summary: `Could not resolve skill href: ${skill.href}`,
+          },
+        ),
+      );
+      continue;
+    }
+    const skillOutcome = await ctx.fetch(target.toString());
+    const skillLabel = `GET ${target.pathname}`;
+    if (
+      skillOutcome.response?.status === 200 &&
+      skillOutcome.body !== undefined &&
+      skillOutcome.body.length > 0
+    ) {
+      resolvedCount++;
+      evidence.push(
+        fetchToStep(skillOutcome, skillLabel, {
+          outcome: "positive",
+          summary: `Skill ${skillDisplayName(skill)} resolved`,
+        }),
+      );
+    } else {
+      evidence.push(
+        fetchToStep(skillOutcome, skillLabel, {
+          outcome: "negative",
+          summary: skillOutcome.response
+            ? `Skill ${skillDisplayName(skill)} returned ${skillOutcome.response.status}`
+            : `Skill ${skillDisplayName(skill)} fetch failed: ${skillOutcome.error ?? "unknown"}`,
+        }),
+      );
+    }
+  }
+
+  // 4. Resolution gate.
+  if (resolvedCount === 0) {
+    evidence.push(
+      makeStep("validate", VALIDATE_RESOLUTION_LABEL, {
+        outcome: "negative",
+        summary: `None of the first ${toResolve.length} skill href(s) resolved with content`,
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_NO_RESOLUTION_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_NO_RESOLUTION_MESSAGE,
+      details: {
+        skillCount: rawSkills.length,
+        resolvedSkills: 0,
+        path: indexPath,
+      },
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  evidence.push(
+    makeStep("validate", VALIDATE_RESOLUTION_LABEL, {
+      outcome: "positive",
+      summary: `Resolved ${resolvedCount}/${toResolve.length} referenced skills`,
+    }),
+  );
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "positive",
+      summary: PASS_MESSAGE,
+    }),
+  );
+
+  const details: Record<string, unknown> = {
+    skillCount: rawSkills.length,
+    resolvedSkills: resolvedCount,
+    path: indexPath,
+  };
+  const specVersion = extractSpecVersion(indexObj);
+  if (specVersion !== undefined) {
+    details.specVersion = specVersion;
+  }
+
+  return {
+    status: "pass",
+    message: PASS_MESSAGE,
+    details,
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}

--- a/lib/engine/checks/web-mcp.ts
+++ b/lib/engine/checks/web-mcp.ts
@@ -53,7 +53,15 @@ const FAIL_MESSAGE = "No WebMCP tools detected on page load";
 const WEBMCP_API_REGEX =
   /navigator\s*\.\s*modelContext\s*\.\s*(registerTool|provideContext)\s*\(/;
 
-/** Match `<script ...>...</script>` non-greedily to capture inline bodies. */
+/**
+ * Match `<script ...>...</script>` non-greedily to capture inline bodies.
+ *
+ * NOTE: this mirrors browser HTML parser rules loosely — it cuts the body at
+ * the first `</script` sequence and does NOT handle `>` characters embedded
+ * inside quoted attribute values (e.g. `<script data-x="a>b">`). Real browsers
+ * tokenise attributes properly; we accept the edge case because the WebMCP
+ * API signature we match is unlikely to appear in such pathological markup.
+ */
 const INLINE_SCRIPT_REGEX = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
 
 /** Match a `src="..."` or `src='...'` or bare `src=...` attribute. */

--- a/lib/engine/checks/web-mcp.ts
+++ b/lib/engine/checks/web-mcp.ts
@@ -1,0 +1,289 @@
+/**
+ * Discovery check: `webMcp`.
+ *
+ * Specification
+ * -------------
+ * Detect WebMCP tool registrations on the page. The reference scanner uses a
+ * real Chromium instance to evaluate page JavaScript and observe
+ * `navigator.modelContext.registerTool()` / `provideContext()` calls at
+ * runtime. We run on Vercel Fluid Compute (Node), so we use a
+ *
+ *     Static fallback only; upgrade path is Vercel Sandbox for real Chromium eval.
+ *
+ * detector that:
+ *   1. Fetches the homepage HTML via ctx.getHomepage().
+ *   2. Extracts every inline `<script>...</script>` block and scans its body
+ *      for `navigator.modelContext.{registerTool|provideContext}`.
+ *   3. Extracts every `<script src="...">` URL, resolves it against the
+ *      homepage origin, and -- ONLY for same-origin scripts (SSRF guard:
+ *      `new URL(src, homepage).origin === homepage.origin`) -- fetches the
+ *      script body and scans it for the same regex. Cross-origin scripts
+ *      are skipped with an explicit evidence step.
+ *   4. Caps the number of linked scripts probed at LINKED_SCRIPT_LIMIT to
+ *      keep the probe budget bounded.
+ *   5. Passes iff any inline or same-origin linked script contains a match.
+ */
+
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import {
+  fetchToStep,
+  makeStep,
+  type FetchOutcome,
+  type ScanContext,
+} from "@/lib/engine/context";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FETCH_HOMEPAGE_LABEL = "GET /";
+const PARSE_INLINE_LABEL = "Scan inline <script> blocks";
+const PARSE_LINKED_INDEX_LABEL = "Enumerate linked <script src> URLs";
+const CONCLUDE_LABEL = "Conclusion";
+
+const PASS_MESSAGE =
+  "WebMCP tool registrations detected via static script analysis";
+const FAIL_MESSAGE = "No WebMCP tools detected on page load";
+
+/**
+ * Matches `navigator.modelContext.registerTool(` or
+ * `navigator.modelContext.provideContext(` anywhere in a script source.
+ * The trailing `(` avoids matching a bare mention in prose or docstrings.
+ */
+const WEBMCP_API_REGEX =
+  /navigator\s*\.\s*modelContext\s*\.\s*(registerTool|provideContext)\s*\(/;
+
+/** Match `<script ...>...</script>` non-greedily to capture inline bodies. */
+const INLINE_SCRIPT_REGEX = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+
+/** Match a `src="..."` or `src='...'` or bare `src=...` attribute. */
+const SCRIPT_SRC_REGEX =
+  /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))/i;
+
+/** Cap on the number of same-origin linked scripts we probe per page. */
+const LINKED_SCRIPT_LIMIT = 20;
+
+// ---------------------------------------------------------------------------
+// HTML parsing helpers
+// ---------------------------------------------------------------------------
+
+interface ScriptScan {
+  readonly inlineBodies: string[];
+  readonly srcUrls: string[];
+}
+
+/**
+ * Extract inline script bodies and script src URLs from an HTML document.
+ * A regex-based approach is sufficient for our static detection use case --
+ * we are not building a full HTML parser; we tolerate malformed markup by
+ * letting unmatched tags be ignored.
+ */
+function scanScripts(html: string): ScriptScan {
+  const inlineBodies: string[] = [];
+  const srcUrls: string[] = [];
+
+  const re = new RegExp(INLINE_SCRIPT_REGEX.source, INLINE_SCRIPT_REGEX.flags);
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    const attrs = match[1] ?? "";
+    const body = match[2] ?? "";
+    const srcMatch = SCRIPT_SRC_REGEX.exec(attrs);
+    if (srcMatch !== null) {
+      const src = srcMatch[1] ?? srcMatch[2] ?? srcMatch[3];
+      if (src !== undefined && src.length > 0) {
+        srcUrls.push(src);
+      }
+    } else if (body.trim().length > 0) {
+      inlineBodies.push(body);
+    }
+  }
+  return { inlineBodies, srcUrls };
+}
+
+function matchWebMcpApi(source: string): string | undefined {
+  const match = WEBMCP_API_REGEX.exec(source);
+  return match?.[1];
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkWebMcp(ctx: ScanContext): Promise<CheckResult> {
+  const started = Date.now();
+  const evidence: EvidenceStep[] = [];
+
+  // 1. Fetch homepage.
+  const homepage: FetchOutcome = await ctx.getHomepage();
+
+  if (homepage.response === undefined) {
+    evidence.push(
+      fetchToStep(homepage, FETCH_HOMEPAGE_LABEL, {
+        outcome: "negative",
+        summary: homepage.error
+          ? `Homepage request failed: ${homepage.error}`
+          : "Homepage request failed with no response",
+      }),
+    );
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  evidence.push(
+    fetchToStep(homepage, FETCH_HOMEPAGE_LABEL, {
+      outcome: "neutral",
+      summary: `Fetched homepage (${homepage.response.status}) for WebMCP static analysis`,
+    }),
+  );
+
+  const html = homepage.body ?? "";
+  const { inlineBodies, srcUrls } = scanScripts(html);
+
+  // 2. Scan inline scripts.
+  let foundIn: string | undefined;
+  let foundPattern: string | undefined;
+
+  for (const body of inlineBodies) {
+    const pattern = matchWebMcpApi(body);
+    if (pattern !== undefined) {
+      foundIn = "inline script";
+      foundPattern = `navigator.modelContext.${pattern}`;
+      break;
+    }
+  }
+
+  evidence.push(
+    makeStep("parse", PARSE_INLINE_LABEL, {
+      outcome: foundIn !== undefined ? "positive" : "neutral",
+      summary:
+        foundIn !== undefined
+          ? `Matched ${foundPattern} in inline script`
+          : `Scanned ${inlineBodies.length} inline script block(s); no match`,
+    }),
+  );
+
+  // 3. Scan linked scripts (same-origin only, with SSRF guard).
+  if (foundIn === undefined && srcUrls.length > 0) {
+    evidence.push(
+      makeStep("parse", PARSE_LINKED_INDEX_LABEL, {
+        outcome: "neutral",
+        summary: `Found ${srcUrls.length} linked <script src> URL(s)`,
+      }),
+    );
+
+    let probed = 0;
+    for (const src of srcUrls) {
+      if (probed >= LINKED_SCRIPT_LIMIT) break;
+
+      let target: URL;
+      try {
+        target = new URL(src, ctx.url);
+      } catch {
+        evidence.push(
+          makeStep("parse", `Resolve script URL ${src}`, {
+            outcome: "negative",
+            summary: `Could not parse script URL: ${src}`,
+          }),
+        );
+        continue;
+      }
+
+      // SSRF guard: only fetch same-origin scripts.
+      if (target.origin !== ctx.url.origin) {
+        evidence.push(
+          makeStep("parse", `Skip cross-origin script ${target.origin}`, {
+            outcome: "neutral",
+            summary: `Skipping cross-origin script: ${target.toString()}`,
+          }),
+        );
+        continue;
+      }
+
+      probed++;
+      const scriptOutcome = await ctx.fetch(target.toString());
+      if (
+        scriptOutcome.response === undefined ||
+        scriptOutcome.response.status !== 200 ||
+        scriptOutcome.body === undefined
+      ) {
+        evidence.push(
+          fetchToStep(scriptOutcome, `GET ${target.pathname}`, {
+            outcome: "negative",
+            summary: scriptOutcome.response
+              ? `Linked script returned ${scriptOutcome.response.status}`
+              : `Linked script fetch failed: ${scriptOutcome.error ?? "unknown"}`,
+          }),
+        );
+        continue;
+      }
+
+      const pattern = matchWebMcpApi(scriptOutcome.body);
+      if (pattern !== undefined) {
+        foundIn = target.toString();
+        foundPattern = `navigator.modelContext.${pattern}`;
+        evidence.push(
+          fetchToStep(scriptOutcome, `GET ${target.pathname}`, {
+            outcome: "positive",
+            summary: `Matched ${foundPattern} in linked script`,
+          }),
+        );
+        break;
+      }
+
+      evidence.push(
+        fetchToStep(scriptOutcome, `GET ${target.pathname}`, {
+          outcome: "neutral",
+          summary: "No WebMCP API reference in linked script",
+        }),
+      );
+    }
+  }
+
+  // 4. Conclude.
+  if (foundIn === undefined) {
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_MESSAGE,
+      }),
+    );
+    return {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "positive",
+      summary: PASS_MESSAGE,
+    }),
+  );
+
+  return {
+    status: "pass",
+    message: PASS_MESSAGE,
+    details: {
+      foundIn,
+      pattern: foundPattern,
+      // Documented limitation so downstream consumers can surface caveats.
+      // Static fallback only; upgrade path is Vercel Sandbox for real
+      // Chromium eval.
+      detectionMode: "static-fallback",
+    },
+    evidence,
+    durationMs: Date.now() - started,
+  };
+}

--- a/tests/engine/a2a-agent-card.spec.ts
+++ b/tests/engine/a2a-agent-card.spec.ts
@@ -205,6 +205,7 @@ describe("a2aAgentCard — edge cases", () => {
     const ctx = createScanContext({ url: "https://min.test", fetchImpl });
     const result = await checkA2aAgentCard(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     expect(result.details?.skillCount).toBe(3);
   });
 });

--- a/tests/engine/a2a-agent-card.spec.ts
+++ b/tests/engine/a2a-agent-card.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * Failing specs for the `a2aAgentCard` check.
+ *
+ * Oracle: `research/raw/scan-*.json` → `checks.discovery.a2aAgentCard`.
+ * Reference: `research/FINDINGS.md` §3, §9.
+ *
+ * Per FINDINGS §9 and the task specification:
+ *   - GET `/.well-known/agent-card.json` on the origin.
+ *   - Pass iff the response is 200 and the body is valid JSON containing at
+ *     least `{ name, version, skills: [...] }`.
+ *   - Fail otherwise (404, transport error, invalid JSON, missing fields).
+ *
+ * NOTE: this check is off by default in the UI (user opt-in via enabledChecks)
+ * but the check itself still runs in the engine. The opt-out behaviour lives
+ * in the scoring layer, not here.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  ALL_SITES,
+  expectCheckMatchesOracle,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema, type EvidenceStep } from "@/lib/schema";
+
+// Not-yet-implemented check; import fails until impl ships the file.
+import { checkA2aAgentCard } from "@/lib/engine/checks/a2a-agent-card";
+
+// ---------------------------------------------------------------------------
+// Oracle harness
+// ---------------------------------------------------------------------------
+
+async function runAgainstOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cardOracle = oracle.raw.checks.discovery.a2aAgentCard as any;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fetchStep = cardOracle.evidence.find(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (s: any) => s.action === "fetch",
+  );
+  if (fetchStep === undefined) {
+    throw new Error(`fixture ${site}: no fetch step found`);
+  }
+
+  const routes: Record<string, Parameters<typeof makeFetchStub>[0][string]> =
+    {};
+  routes[fetchStep.request.url] = {
+    status: fetchStep.response.status,
+    statusText: fetchStep.response.statusText,
+    headers: fetchStep.response.headers,
+    body: "",
+  };
+
+  const { fetchImpl } = makeFetchStub(routes);
+  const ctx = createScanContext({ url: oracle.origin, fetchImpl });
+  const result = await checkA2aAgentCard(ctx);
+  return { oracle: cardOracle, result };
+}
+
+// ---------------------------------------------------------------------------
+// Oracle round-trip — all fixtures fail (none of them serve an agent card)
+// ---------------------------------------------------------------------------
+
+describe("a2aAgentCard", () => {
+  it.each(ALL_SITES)(
+    "%s: round-trips against the fixture oracle",
+    async (site) => {
+      const { oracle, result } = await runAgainstOracle(site);
+      expect(CheckResultSchema.safeParse(result).success).toBe(true);
+      expectCheckMatchesOracle(result, oracle);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases / pass behaviour
+// ---------------------------------------------------------------------------
+
+describe("a2aAgentCard — edge cases", () => {
+  it("passes when agent-card.json returns a valid card", async () => {
+    const body = JSON.stringify({
+      name: "Example Agent",
+      version: "1.0.0",
+      description: "Demo",
+      skills: [{ id: "search", name: "Search", description: "Search content" }],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://ok.test/.well-known/agent-card.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: "https://ok.test", fetchImpl });
+    const result = await checkA2aAgentCard(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.details).toMatchObject({
+      name: "Example Agent",
+      version: "1.0.0",
+      skillCount: 1,
+    });
+    // Evidence: fetch → validate (JSON) → validate (shape) → conclude.
+    expect(result.evidence.map((s: EvidenceStep) => s.action)).toEqual([
+      "fetch",
+      "validate",
+      "validate",
+      "conclude",
+    ]);
+  });
+
+  it("fails when agent-card.json is 200 but not valid JSON", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://bad.test/.well-known/agent-card.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: "{ not json",
+      },
+    });
+    const ctx = createScanContext({ url: "https://bad.test", fetchImpl });
+    const result = await checkA2aAgentCard(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.message).toMatch(/invalid json|not valid json/i);
+  });
+
+  it("fails when agent-card.json is valid JSON but missing required fields", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://partial.test/.well-known/agent-card.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "x" }), // no version, no skills
+      },
+    });
+    const ctx = createScanContext({ url: "https://partial.test", fetchImpl });
+    const result = await checkA2aAgentCard(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.message).toMatch(/missing|invalid/i);
+  });
+
+  it("fails when agent-card.json has empty skills array", async () => {
+    const body = JSON.stringify({
+      name: "No Skills Agent",
+      version: "1.0.0",
+      skills: [],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://noskills.test/.well-known/agent-card.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: "https://noskills.test", fetchImpl });
+    const result = await checkA2aAgentCard(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails (not throws) when the fetch errors at the transport level", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://broken.test/.well-known/agent-card.json": new Error("ECONNRESET"),
+    });
+    const ctx = createScanContext({ url: "https://broken.test", fetchImpl });
+    const result = await checkA2aAgentCard(ctx);
+    expect(result.status).toBe("fail");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+    const fetchStep = result.evidence.find((s) => s.action === "fetch")!;
+    expect(fetchStep.response).toBeUndefined();
+  });
+
+  it("records the fallback fetch-error summary when the error has no message", async () => {
+    const emptyErr = new Error("");
+    const { fetchImpl } = makeFetchStub({
+      "https://silent.test/.well-known/agent-card.json": emptyErr,
+    });
+    const ctx = createScanContext({ url: "https://silent.test", fetchImpl });
+    const result = await checkA2aAgentCard(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("passes validation when skills entries omit optional fields", async () => {
+    // Per task spec, only top-level { name, version, skills: [...] } is
+    // required — individual skill entries don't need strict validation.
+    const body = JSON.stringify({
+      name: "Minimal",
+      version: "0.1",
+      skills: [{ id: "a" }, { id: "b" }, { id: "c" }],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://min.test/.well-known/agent-card.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: "https://min.test", fetchImpl });
+    const result = await checkA2aAgentCard(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.details?.skillCount).toBe(3);
+  });
+});

--- a/tests/engine/a2a-agent-card.spec.ts
+++ b/tests/engine/a2a-agent-card.spec.ts
@@ -99,6 +99,7 @@ describe("a2aAgentCard — edge cases", () => {
     });
     const ctx = createScanContext({ url: "https://ok.test", fetchImpl });
     const result = await checkA2aAgentCard(ctx);
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     expect(result.status).toBe("pass");
     expect(result.details).toMatchObject({
       name: "Example Agent",

--- a/tests/engine/a2a-agent-card.spec.ts
+++ b/tests/engine/a2a-agent-card.spec.ts
@@ -39,7 +39,6 @@ async function runAgainstOracle(site: OracleSite) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cardOracle = oracle.raw.checks.discovery.a2aAgentCard as any;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fetchStep = cardOracle.evidence.find(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (s: any) => s.action === "fetch",

--- a/tests/engine/agent-skills.spec.ts
+++ b/tests/engine/agent-skills.spec.ts
@@ -165,6 +165,7 @@ describe("agentSkills — pass behaviour", () => {
     const ctx = createScanContext({ url: "https://legacy.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     expect(result.details?.path).toBe("/.well-known/skills/index.json");
   });
 
@@ -197,6 +198,7 @@ describe("agentSkills — pass behaviour", () => {
     const ctx = createScanContext({ url: "https://cf-shape.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     expect(result.details?.specVersion).toBe("0.1.0");
     expect(result.details?.path).toBe("/.well-known/skills/index.json");
   });
@@ -257,6 +259,7 @@ describe("agentSkills — pass behaviour", () => {
     const ctx = createScanContext({ url: "https://url-field.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
   });
 
   it("fails when index JSON is malformed", async () => {
@@ -341,6 +344,7 @@ describe("agentSkills — pass behaviour", () => {
     const ctx = createScanContext({ url: "https://cap.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     // s4, s5 must never be fetched.
     expect(calls.some((u) => u.includes("/s4/"))).toBe(false);
     expect(calls.some((u) => u.includes("/s5/"))).toBe(false);
@@ -385,6 +389,7 @@ describe("agentSkills — pass behaviour", () => {
     const ctx = createScanContext({ url: "https://mixed.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
   });
 
   it("fails when index body is valid JSON but root is not an object (scalar)", async () => {
@@ -441,6 +446,7 @@ describe("agentSkills — pass behaviour", () => {
     const result = await checkAgentSkills(ctx);
     // At least one resolved, so we expect pass (despite one unparseable href).
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
   });
 
   it("emits evidence steps in the expected order on a full pass", async () => {

--- a/tests/engine/agent-skills.spec.ts
+++ b/tests/engine/agent-skills.spec.ts
@@ -55,7 +55,6 @@ async function runFailOracle(site: OracleSite) {
 
   const routes: Record<string, Parameters<typeof makeFetchStub>[0][string]> =
     {};
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   skillsOracle.evidence
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .filter((s: any) => s.action === "fetch")
@@ -351,6 +350,62 @@ describe("agentSkills — pass behaviour", () => {
     });
     const ctx = createScanContext({ url: "https://mixed.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when index body is valid JSON but root is not an object (scalar)", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://scalar.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify("just a string"),
+      },
+    });
+    const ctx = createScanContext({ url: "https://scalar.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.message).toMatch(/not valid json|json/i);
+  });
+
+  it("fails when index body is null (valid JSON but not an object)", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://null.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: "null",
+      },
+    });
+    const ctx = createScanContext({ url: "https://null.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("records a resolve-error step when a skill href is unparseable", async () => {
+    const indexBody = JSON.stringify({
+      skills: [
+        { id: "bad", href: "ht!tp://:::not a url" },
+        { id: "ok", href: "/ok/SKILL.md" },
+      ],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://resolver.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://resolver.test/ok/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "# OK",
+      },
+    });
+    const ctx = createScanContext({ url: "https://resolver.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    // At least one resolved, so we expect pass (despite one unparseable href).
     expect(result.status).toBe("pass");
   });
 

--- a/tests/engine/agent-skills.spec.ts
+++ b/tests/engine/agent-skills.spec.ts
@@ -1,0 +1,382 @@
+/**
+ * Failing specs for the `agentSkills` check.
+ *
+ * Oracle: `research/raw/scan-*.json` → `checks.discovery.agentSkills`.
+ * Reference: `research/FINDINGS.md` §3, §9.
+ *
+ * Per FINDINGS §9 and the task specification:
+ *   - GET `/.well-known/agent-skills/index.json` (v0.2.0 path) on the origin.
+ *   - On 404, fall back to the legacy `/.well-known/skills/index.json` path,
+ *     mirroring Cloudflare's real scanner behaviour (see cf-dev fixture:
+ *     v0.2.0 path returned 404, legacy path returned 200 — PASS).
+ *   - Parse the JSON. Expect a `skills: []` array; each entry may carry
+ *     `{ id | name, description, url | href }` per the RFC v0.2.0 schema
+ *     (also accepts the FINDINGS §3 shorthand `{ id, name, href }`).
+ *   - Attempt to resolve the first 3 skill hrefs (same-origin or absolute);
+ *     pass if the index is valid JSON AND at least one skill resolves with
+ *     a non-empty body.
+ *
+ * The four "fail" oracle fixtures exercise the legacy-fallback + conclusion
+ * path. The cf-dev pass fixture does not include skill-href resolution steps
+ * (it's the real scanner's 0.1.0-shape output), so it is covered here by a
+ * dedicated custom fixture that exercises the resolver contract.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  expectCheckMatchesOracle,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema, type EvidenceStep } from "@/lib/schema";
+
+// Not-yet-implemented check; import fails until impl ships the file.
+import { checkAgentSkills } from "@/lib/engine/checks/agent-skills";
+
+// ---------------------------------------------------------------------------
+// Oracle harness — only the 4 failing fixtures match our contract cleanly.
+// ---------------------------------------------------------------------------
+
+/** Sites whose oracle evidence shape matches our implementation exactly. */
+const FAIL_FIXTURE_SITES: readonly OracleSite[] = [
+  "example",
+  "vercel",
+  "cf",
+  "shopify",
+] as const;
+
+async function runFailOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const skillsOracle = oracle.raw.checks.discovery.agentSkills as any;
+
+  const routes: Record<string, Parameters<typeof makeFetchStub>[0][string]> =
+    {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  skillsOracle.evidence
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((s: any) => s.action === "fetch")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .forEach((step: any) => {
+      routes[step.request.url] = {
+        status: step.response.status,
+        statusText: step.response.statusText,
+        headers: step.response.headers,
+        body: "",
+      };
+    });
+
+  const { fetchImpl } = makeFetchStub(routes);
+  const ctx = createScanContext({ url: oracle.origin, fetchImpl });
+  const result = await checkAgentSkills(ctx);
+  return { oracle: skillsOracle, result };
+}
+
+describe("agentSkills", () => {
+  it.each(FAIL_FIXTURE_SITES)(
+    "%s: round-trips against the fail-case fixture oracle",
+    async (site) => {
+      const { oracle, result } = await runFailOracle(site);
+      expect(CheckResultSchema.safeParse(result).success).toBe(true);
+      expectCheckMatchesOracle(result, oracle);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Pass behaviour — custom fixture exercising skill-href resolution.
+// ---------------------------------------------------------------------------
+
+describe("agentSkills — pass behaviour", () => {
+  it("passes when the v0.2.0 index is served and at least one skill resolves", async () => {
+    const indexBody = JSON.stringify({
+      $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+      skills: [
+        { id: "search", name: "Search", href: "/.well-known/skills/search/SKILL.md" },
+        { id: "nav", name: "Nav", href: "/.well-known/skills/nav/SKILL.md" },
+        { id: "lookup", name: "Lookup", href: "/.well-known/skills/lookup/SKILL.md" },
+      ],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://ok.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://ok.test/.well-known/skills/search/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/markdown" },
+        body: "# Search Skill\nBody content.",
+      },
+      "https://ok.test/.well-known/skills/nav/SKILL.md": {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html" },
+        body: "",
+      },
+      "https://ok.test/.well-known/skills/lookup/SKILL.md": {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html" },
+        body: "",
+      },
+    });
+    const ctx = createScanContext({ url: "https://ok.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.details).toMatchObject({
+      skillCount: 3,
+      resolvedSkills: 1,
+      path: "/.well-known/agent-skills/index.json",
+    });
+  });
+
+  it("passes when legacy /.well-known/skills/index.json is the only index available", async () => {
+    const indexBody = JSON.stringify({
+      skills: [
+        { id: "about", name: "About", href: "/skills/about/SKILL.md" },
+      ],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://legacy.test/.well-known/agent-skills/index.json": {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html" },
+        body: "",
+      },
+      "https://legacy.test/.well-known/skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://legacy.test/skills/about/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/markdown" },
+        body: "# About",
+      },
+    });
+    const ctx = createScanContext({ url: "https://legacy.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.details?.path).toBe("/.well-known/skills/index.json");
+  });
+
+  it("fails when the index is valid JSON but no skill hrefs resolve", async () => {
+    const indexBody = JSON.stringify({
+      skills: [
+        { id: "a", name: "A", href: "/skills/a/SKILL.md" },
+        { id: "b", name: "B", href: "/skills/b/SKILL.md" },
+      ],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://unresolved.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://unresolved.test/skills/a/SKILL.md": {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html" },
+        body: "",
+      },
+      "https://unresolved.test/skills/b/SKILL.md": {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html" },
+        body: "",
+      },
+    });
+    const ctx = createScanContext({ url: "https://unresolved.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.message).toMatch(/no skill|resolve/i);
+  });
+
+  it("accepts 'url' as an alternative to 'href' for the skill location", async () => {
+    const indexBody = JSON.stringify({
+      skills: [
+        { name: "search", url: "/skills/search/SKILL.md", type: "skill-md" },
+      ],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://url-field.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://url-field.test/skills/search/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/markdown" },
+        body: "# Search",
+      },
+    });
+    const ctx = createScanContext({ url: "https://url-field.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when index JSON is malformed", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://bad.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: "{ broken",
+      },
+    });
+    const ctx = createScanContext({ url: "https://bad.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.message).toMatch(/invalid|parse|json/i);
+  });
+
+  it("fails when index is valid JSON but missing the skills array", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://empty.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ $schema: "foo" }),
+      },
+    });
+    const ctx = createScanContext({ url: "https://empty.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when skills array is empty", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://noskills.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ skills: [] }),
+      },
+    });
+    const ctx = createScanContext({ url: "https://noskills.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("resolves at most the first 3 skill hrefs", async () => {
+    const indexBody = JSON.stringify({
+      skills: [
+        { id: "s1", href: "/s1/SKILL.md" },
+        { id: "s2", href: "/s2/SKILL.md" },
+        { id: "s3", href: "/s3/SKILL.md" },
+        { id: "s4", href: "/s4/SKILL.md" },
+        { id: "s5", href: "/s5/SKILL.md" },
+      ],
+    });
+    const { fetchImpl, calls } = makeFetchStub({
+      "https://cap.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://cap.test/s1/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "# S1",
+      },
+      "https://cap.test/s2/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "# S2",
+      },
+      "https://cap.test/s3/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "# S3",
+      },
+    });
+    const ctx = createScanContext({ url: "https://cap.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("pass");
+    // s4, s5 must never be fetched.
+    expect(calls.some((u) => u.includes("/s4/"))).toBe(false);
+    expect(calls.some((u) => u.includes("/s5/"))).toBe(false);
+  });
+
+  it("fails (not throws) when the index fetch errors at the transport level on both paths", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://broken.test/.well-known/agent-skills/index.json": new Error(
+        "ECONNRESET",
+      ),
+      "https://broken.test/.well-known/skills/index.json": new Error(
+        "ECONNRESET",
+      ),
+    });
+    const ctx = createScanContext({ url: "https://broken.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("fail");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+  });
+
+  it("skips skill entries that have no href/url", async () => {
+    const indexBody = JSON.stringify({
+      skills: [
+        { id: "nohref" }, // no href/url — must be skipped without crashing
+        { id: "ok", href: "/skills/ok/SKILL.md" },
+      ],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://mixed.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://mixed.test/skills/ok/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "# OK",
+      },
+    });
+    const ctx = createScanContext({ url: "https://mixed.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("emits evidence steps in the expected order on a full pass", async () => {
+    const indexBody = JSON.stringify({
+      skills: [{ id: "x", href: "/x/SKILL.md" }],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://ordered.test/.well-known/agent-skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://ordered.test/x/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "# X body",
+      },
+    });
+    const ctx = createScanContext({ url: "https://ordered.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    const actions = result.evidence.map((s: EvidenceStep) => s.action);
+    // Expected flow: fetch index, parse JSON, fetch skill, conclude.
+    expect(actions[0]).toBe("fetch");
+    expect(actions[actions.length - 1]).toBe("conclude");
+  });
+});

--- a/tests/engine/agent-skills.spec.ts
+++ b/tests/engine/agent-skills.spec.ts
@@ -127,6 +127,7 @@ describe("agentSkills — pass behaviour", () => {
     });
     const ctx = createScanContext({ url: "https://ok.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     expect(result.status).toBe("pass");
     expect(result.details).toMatchObject({
       skillCount: 3,
@@ -164,6 +165,39 @@ describe("agentSkills — pass behaviour", () => {
     const ctx = createScanContext({ url: "https://legacy.test", fetchImpl });
     const result = await checkAgentSkills(ctx);
     expect(result.status).toBe("pass");
+    expect(result.details?.path).toBe("/.well-known/skills/index.json");
+  });
+
+  it("emits specVersion '0.1.0' on a legacy-shape pass (cf-dev oracle parity)", async () => {
+    // Legacy body: no $schema, under /.well-known/skills/index.json — matches
+    // the reference scanner's cf-dev fixture (see research/raw/scan-cf-dev.json).
+    const indexBody = JSON.stringify({
+      skills: [{ id: "demo", name: "Demo", href: "/skills/demo/SKILL.md" }],
+    });
+    const { fetchImpl } = makeFetchStub({
+      "https://cf-shape.test/.well-known/agent-skills/index.json": {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html" },
+        body: "",
+      },
+      "https://cf-shape.test/.well-known/skills/index.json": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: indexBody,
+      },
+      "https://cf-shape.test/skills/demo/SKILL.md": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/markdown" },
+        body: "# Demo",
+      },
+    });
+    const ctx = createScanContext({ url: "https://cf-shape.test", fetchImpl });
+    const result = await checkAgentSkills(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.details?.specVersion).toBe("0.1.0");
     expect(result.details?.path).toBe("/.well-known/skills/index.json");
   });
 

--- a/tests/engine/web-mcp.spec.ts
+++ b/tests/engine/web-mcp.spec.ts
@@ -76,6 +76,7 @@ describe("webMcp — static fallback pass paths", () => {
     const ctx = createScanContext({ url: "https://provide.test", fetchImpl });
     const result = await checkWebMcp(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
   });
 
   it("passes when a same-origin linked script contains the API call", async () => {
@@ -99,6 +100,7 @@ describe("webMcp — static fallback pass paths", () => {
     const ctx = createScanContext({ url: "https://linked.test", fetchImpl });
     const result = await checkWebMcp(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
   });
 });
 
@@ -183,6 +185,32 @@ describe("webMcp — SSRF guard", () => {
     expect(skipStep).toBeDefined();
   });
 
+  it("skips protocol-relative script URLs with userinfo spoofing the origin host", async () => {
+    // Sanity check: the userinfo form really does resolve to evil.com — if this
+    // invariant ever breaks, the test below needs to be revisited.
+    expect(
+      new URL("//guard.test@evil.com/x.js", "https://guard.test/").origin,
+    ).toBe("https://evil.com");
+
+    const html = `<html><body>
+      <script src="//guard.test@evil.com/x.js"></script>
+    </body></html>`;
+    const { fetchImpl, calls } = makeFetchStub({
+      "https://guard.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://guard.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    // The attacker host must never be contacted, nor the raw userinfo URL.
+    expect(calls.some((u) => u.includes("evil.com"))).toBe(false);
+    expect(calls.some((u) => u.includes("guard.test@"))).toBe(false);
+  });
+
   it("allows absolute same-origin script URLs", async () => {
     const html = `<html><body>
       <script src="https://same.test/bundle.js"></script>
@@ -204,6 +232,7 @@ describe("webMcp — SSRF guard", () => {
     const ctx = createScanContext({ url: "https://same.test", fetchImpl });
     const result = await checkWebMcp(ctx);
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
   });
 });
 
@@ -259,6 +288,29 @@ describe("webMcp — fail paths", () => {
     const ctx = createScanContext({ url: "https://scripts404.test", fetchImpl });
     const result = await checkWebMcp(ctx);
     expect(result.status).toBe("fail");
+  });
+
+  it("regex limitation: quoted '>' in script attribute still yields a match on the truncated body (known gap, locked for review)", async () => {
+    // INLINE_SCRIPT_REGEX uses `[^>]*` for the opening tag, so a quoted '>' in
+    // an attribute terminates the attribute list early — see the iter-2
+    // comment in lib/engine/checks/web-mcp.ts. For this exact input the
+    // truncated body ("b\">navigator.modelContext.registerTool({})") still
+    // contains the API signature, so the scan currently *passes*. Locked here
+    // so any future regex change that shifts this behaviour (in either
+    // direction) must be reviewed explicitly.
+    const html = `<script data-x="a>b">navigator.modelContext.registerTool({})</script>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://regex-edge.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://regex-edge.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
   });
 
   it("does NOT falsely detect a superficial mention in prose", async () => {
@@ -381,6 +433,7 @@ describe("webMcp — robustness", () => {
     const result = await checkWebMcp(ctx);
     // The unparseable entry is recorded, and the good one still passes.
     expect(result.status).toBe("pass");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     const parseErr = result.evidence.find((s) =>
       s.finding.summary.toLowerCase().includes("could not parse script url"),
     );

--- a/tests/engine/web-mcp.spec.ts
+++ b/tests/engine/web-mcp.spec.ts
@@ -1,0 +1,333 @@
+/**
+ * Failing specs for the `webMcp` check.
+ *
+ * Oracle: `research/raw/scan-*.json` → `checks.discovery.webMcp`.
+ * Reference: `research/FINDINGS.md` §3, §9, §13 (gaps).
+ *
+ * IMPLEMENTATION NOTE: the reference scanner uses a headless Chromium to
+ * evaluate page JS and detect `navigator.modelContext.{registerTool,
+ * provideContext}` calls at runtime. Our static fallback cannot do real JS
+ * evaluation, so evidence steps diverge from the oracle shape. What we CAN
+ * honour on-oracle is the final `status` and `message`: every fixture's site
+ * lacks any static reference to `navigator.modelContext`, and we produce the
+ * same `"No WebMCP tools detected on page load"` fail verdict.
+ *
+ * Static-fallback detection flow:
+ *   1. Fetch the homepage HTML.
+ *   2. Scan all inline <script> blocks for the regex.
+ *   3. Collect all <script src="..."> URLs; fetch each same-origin script and
+ *      scan its body for the regex (SSRF guard: skip cross-origin). Emit an
+ *      evidence step noting each cross-origin skip.
+ *   4. Pass if ANY source contains `navigator.modelContext.registerTool` or
+ *      `navigator.modelContext.provideContext`.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  ALL_SITES,
+  loadOracle,
+  makeFetchStub,
+  type OracleSite,
+} from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema, type EvidenceStep } from "@/lib/schema";
+
+// Not-yet-implemented check; import fails until impl ships the file.
+import { checkWebMcp } from "@/lib/engine/checks/web-mcp";
+
+// ---------------------------------------------------------------------------
+// Oracle round-trip — we assert on status + message only (evidence shape
+// diverges because we're a static fallback, not a real browser).
+// ---------------------------------------------------------------------------
+
+async function runOracle(site: OracleSite) {
+  const oracle = loadOracle(site);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const webMcpOracle = oracle.raw.checks.discovery.webMcp as any;
+
+  // Every fixture's oracle records "No WebMCP tools". Our static fallback
+  // must still produce that verdict when the homepage has no references and
+  // no linked scripts do either. We stub the homepage with an empty HTML
+  // body so the fallback exits cleanly.
+  const routes: Record<string, Parameters<typeof makeFetchStub>[0][string]> = {
+    [`${oracle.origin}/`]: {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "text/html" },
+      body: "<!doctype html><html><head></head><body>no tools</body></html>",
+    },
+  };
+
+  const { fetchImpl } = makeFetchStub(routes);
+  const ctx = createScanContext({ url: oracle.origin, fetchImpl });
+  const result = await checkWebMcp(ctx);
+  return { oracle: webMcpOracle, result };
+}
+
+describe("webMcp", () => {
+  it.each(ALL_SITES)(
+    "%s: status + message match the oracle (evidence shape diverges by design)",
+    async (site) => {
+      const { oracle, result } = await runOracle(site);
+      expect(CheckResultSchema.safeParse(result).success).toBe(true);
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Static fallback — pass paths
+// ---------------------------------------------------------------------------
+
+describe("webMcp — static fallback pass paths", () => {
+  it("passes when the homepage contains inline navigator.modelContext.registerTool", async () => {
+    const html = `<!doctype html><html><body>
+      <script>
+        navigator.modelContext.registerTool({ name: "search" });
+      </script>
+    </body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://inline.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://inline.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.message).toMatch(/webmcp|modelcontext|detected/i);
+    expect(result.details).toMatchObject({
+      foundIn: expect.any(String),
+      pattern: expect.any(String),
+    });
+  });
+
+  it("passes when the homepage inline script uses provideContext", async () => {
+    const html = `<html><body><script>
+      navigator.modelContext.provideContext({ hint: "ok" });
+    </script></body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://provide.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://provide.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes when a same-origin linked script contains the API call", async () => {
+    const html = `<html><body>
+      <script src="/assets/app.js"></script>
+    </body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://linked.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      "https://linked.test/assets/app.js": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/javascript" },
+        body: "navigator.modelContext.registerTool({ name: 'x' });",
+      },
+    });
+    const ctx = createScanContext({ url: "https://linked.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSRF guard — cross-origin scripts must be skipped, with evidence.
+// ---------------------------------------------------------------------------
+
+describe("webMcp — SSRF guard", () => {
+  it("skips cross-origin script tags and emits a skip evidence step", async () => {
+    const html = `<html><body>
+      <script src="https://cdn.example.com/external.js"></script>
+    </body></html>`;
+    const { fetchImpl, calls } = makeFetchStub({
+      "https://guard.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://guard.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    // Cross-origin script must never have been fetched.
+    expect(calls.some((u) => u.startsWith("https://cdn.example.com/"))).toBe(
+      false,
+    );
+    const skipStep = result.evidence.find(
+      (s) =>
+        s.finding.summary.toLowerCase().includes("cross-origin") ||
+        s.finding.summary.toLowerCase().includes("skip"),
+    );
+    expect(skipStep).toBeDefined();
+  });
+
+  it("allows absolute same-origin script URLs", async () => {
+    const html = `<html><body>
+      <script src="https://same.test/bundle.js"></script>
+    </body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://same.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      "https://same.test/bundle.js": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/javascript" },
+        body: "navigator.modelContext.registerTool({});",
+      },
+    });
+    const ctx = createScanContext({ url: "https://same.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail paths and robustness
+// ---------------------------------------------------------------------------
+
+describe("webMcp — fail paths", () => {
+  it("fails when the homepage has no navigator.modelContext references at all", async () => {
+    const html = "<html><body><script>console.log('nothing')</script></body></html>";
+    const { fetchImpl } = makeFetchStub({
+      "https://nope.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://nope.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("No WebMCP tools detected on page load");
+  });
+
+  it("fails (not throws) when the homepage fetch errors at the transport level", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://broken.test/": new Error("ECONNRESET"),
+    });
+    const ctx = createScanContext({ url: "https://broken.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+  });
+
+  it("fails gracefully when a linked same-origin script 404s", async () => {
+    const html = `<html><body>
+      <script src="/missing.js"></script>
+    </body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://scripts404.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      "https://scripts404.test/missing.js": {
+        status: 404,
+        statusText: "Not Found",
+        headers: {},
+        body: "",
+      },
+    });
+    const ctx = createScanContext({ url: "https://scripts404.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("does NOT falsely detect a superficial mention in prose", async () => {
+    const html = `<html><body>
+      <p>We do not use navigator.modelContext on this page.</p>
+    </body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://prose.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://prose.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    // "navigator.modelContext" alone (no .registerTool / .provideContext) is
+    // not a positive signal — the check must remain a fail.
+    expect(result.status).toBe("fail");
+  });
+
+  it("caps the number of linked scripts fetched to avoid ballooning probe count", async () => {
+    // Many same-origin scripts: implementation should cap at a reasonable N.
+    const scriptTags = Array.from(
+      { length: 25 },
+      (_, i) => `<script src="/s${i}.js"></script>`,
+    ).join("");
+    const html = `<html><body>${scriptTags}</body></html>`;
+    const routes: Record<string, Parameters<typeof makeFetchStub>[0][string]> =
+      {
+        "https://many.test/": {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "text/html" },
+          body: html,
+        },
+      };
+    for (let i = 0; i < 25; i++) {
+      routes[`https://many.test/s${i}.js`] = {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/javascript" },
+        body: "/* empty */",
+      };
+    }
+    const { fetchImpl, calls } = makeFetchStub(routes);
+    const ctx = createScanContext({ url: "https://many.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    // Homepage + at most 20 scripts fetched (implementation cap).
+    expect(calls.length).toBeLessThanOrEqual(21);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evidence shape
+// ---------------------------------------------------------------------------
+
+describe("webMcp — evidence shape", () => {
+  it("records a fetch step for the homepage probe", async () => {
+    const html = "<html/>";
+    const { fetchImpl } = makeFetchStub({
+      "https://shape.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://shape.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    const actions = result.evidence.map((s: EvidenceStep) => s.action);
+    expect(actions[0]).toBe("fetch");
+    expect(actions[actions.length - 1]).toBe("conclude");
+  });
+});

--- a/tests/engine/web-mcp.spec.ts
+++ b/tests/engine/web-mcp.spec.ts
@@ -313,6 +313,72 @@ describe("webMcp — fail paths", () => {
 // Evidence shape
 // ---------------------------------------------------------------------------
 
+describe("webMcp — robustness", () => {
+  it("records the fallback summary when the homepage transport error has no message", async () => {
+    const { fetchImpl } = makeFetchStub({
+      "https://silent.test/": new Error(""),
+    });
+    const ctx = createScanContext({ url: "https://silent.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    const fetchStep = result.evidence.find((s) => s.action === "fetch")!;
+    expect(fetchStep.finding.summary).toBe(
+      "Homepage request failed with no response",
+    );
+  });
+
+  it("records a transport-error summary when a linked same-origin script errors", async () => {
+    const html = `<html><body>
+      <script src="/broken.js"></script>
+    </body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://scripterr.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      "https://scripterr.test/broken.js": new Error("ECONNRESET"),
+    });
+    const ctx = createScanContext({ url: "https://scripterr.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    const errStep = result.evidence.find((s) =>
+      s.finding.summary.toLowerCase().includes("fetch failed"),
+    );
+    expect(errStep).toBeDefined();
+  });
+
+  it("records a parse-error step when a script src URL is unparseable", async () => {
+    const html = `<html><body>
+      <script src="http://"></script>
+      <script src="/ok.js"></script>
+    </body></html>`;
+    const { fetchImpl } = makeFetchStub({
+      "https://badsrc.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      "https://badsrc.test/ok.js": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/javascript" },
+        body: "navigator.modelContext.registerTool({});",
+      },
+    });
+    const ctx = createScanContext({ url: "https://badsrc.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    // The unparseable entry is recorded, and the good one still passes.
+    expect(result.status).toBe("pass");
+    const parseErr = result.evidence.find((s) =>
+      s.finding.summary.toLowerCase().includes("could not parse script url"),
+    );
+    expect(parseErr).toBeDefined();
+  });
+});
+
 describe("webMcp — evidence shape", () => {
   it("records a fetch step for the homepage probe", async () => {
     const html = "<html/>";

--- a/tests/engine/web-mcp.spec.ts
+++ b/tests/engine/web-mcp.spec.ts
@@ -1,16 +1,17 @@
 /**
- * Failing specs for the `webMcp` check.
+ * Specs for the `webMcp` check.
  *
- * Oracle: `research/raw/scan-*.json` → `checks.discovery.webMcp`.
  * Reference: `research/FINDINGS.md` §3, §9, §13 (gaps).
  *
- * IMPLEMENTATION NOTE: the reference scanner uses a headless Chromium to
- * evaluate page JS and detect `navigator.modelContext.{registerTool,
- * provideContext}` calls at runtime. Our static fallback cannot do real JS
- * evaluation, so evidence steps diverge from the oracle shape. What we CAN
- * honour on-oracle is the final `status` and `message`: every fixture's site
- * lacks any static reference to `navigator.modelContext`, and we produce the
- * same `"No WebMCP tools detected on page load"` fail verdict.
+ * webMcp has no structural oracle coverage by design — the reference scanner
+ * uses a headless Chromium instance to evaluate page JS at runtime and detect
+ * `navigator.modelContext.{registerTool,provideContext}` calls live. A static
+ * scanner cannot match the Chromium-based oracle's evidence shape, and a
+ * trivial "every fixture exits cleanly" loop would be tautological (it would
+ * only assert the final `status`+`message` against an identical stubbed
+ * empty-HTML homepage for every site). Instead, we exercise the static
+ * fallback directly against hand-rolled fixtures below: pass paths (inline +
+ * linked), the SSRF guard, fail paths, and robustness cases.
  *
  * Static-fallback detection flow:
  *   1. Fetch the homepage HTML.
@@ -24,58 +25,11 @@
 
 import { describe, it, expect } from "vitest";
 
-import {
-  ALL_SITES,
-  loadOracle,
-  makeFetchStub,
-  type OracleSite,
-} from "./_helpers/oracle";
+import { makeFetchStub } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema, type EvidenceStep } from "@/lib/schema";
 
-// Not-yet-implemented check; import fails until impl ships the file.
 import { checkWebMcp } from "@/lib/engine/checks/web-mcp";
-
-// ---------------------------------------------------------------------------
-// Oracle round-trip — we assert on status + message only (evidence shape
-// diverges because we're a static fallback, not a real browser).
-// ---------------------------------------------------------------------------
-
-async function runOracle(site: OracleSite) {
-  const oracle = loadOracle(site);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const webMcpOracle = oracle.raw.checks.discovery.webMcp as any;
-
-  // Every fixture's oracle records "No WebMCP tools". Our static fallback
-  // must still produce that verdict when the homepage has no references and
-  // no linked scripts do either. We stub the homepage with an empty HTML
-  // body so the fallback exits cleanly.
-  const routes: Record<string, Parameters<typeof makeFetchStub>[0][string]> = {
-    [`${oracle.origin}/`]: {
-      status: 200,
-      statusText: "OK",
-      headers: { "content-type": "text/html" },
-      body: "<!doctype html><html><head></head><body>no tools</body></html>",
-    },
-  };
-
-  const { fetchImpl } = makeFetchStub(routes);
-  const ctx = createScanContext({ url: oracle.origin, fetchImpl });
-  const result = await checkWebMcp(ctx);
-  return { oracle: webMcpOracle, result };
-}
-
-describe("webMcp", () => {
-  it.each(ALL_SITES)(
-    "%s: status + message match the oracle (evidence shape diverges by design)",
-    async (site) => {
-      const { oracle, result } = await runOracle(site);
-      expect(CheckResultSchema.safeParse(result).success).toBe(true);
-      expect(result.status).toBe(oracle.status);
-      expect(result.message).toBe(oracle.message);
-    },
-  );
-});
 
 // ---------------------------------------------------------------------------
 // Static fallback — pass paths
@@ -98,6 +52,7 @@ describe("webMcp — static fallback pass paths", () => {
     });
     const ctx = createScanContext({ url: "https://inline.test", fetchImpl });
     const result = await checkWebMcp(ctx);
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
     expect(result.status).toBe("pass");
     expect(result.message).toMatch(/webmcp|modelcontext|detected/i);
     expect(result.details).toMatchObject({
@@ -175,6 +130,55 @@ describe("webMcp — SSRF guard", () => {
       (s) =>
         s.finding.summary.toLowerCase().includes("cross-origin") ||
         s.finding.summary.toLowerCase().includes("skip"),
+    );
+    expect(skipStep).toBeDefined();
+  });
+
+  it("skips same-host-different-port scripts (distinct origin per RFC 6454)", async () => {
+    const html = `<html><body>
+      <script src="https://guard.test:8443/x.js"></script>
+    </body></html>`;
+    const { fetchImpl, calls } = makeFetchStub({
+      "https://guard.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://guard.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    expect(
+      calls.some((u) => u.startsWith("https://guard.test:8443/")),
+    ).toBe(false);
+    const skipStep = result.evidence.find((s) =>
+      s.finding.summary.toLowerCase().includes("cross-origin"),
+    );
+    expect(skipStep).toBeDefined();
+  });
+
+  it("skips protocol-relative script URLs that resolve to a different host", async () => {
+    const html = `<html><body>
+      <script src="//cdn.evil.com/x.js"></script>
+    </body></html>`;
+    const { fetchImpl, calls } = makeFetchStub({
+      "https://guard.test/": {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+    });
+    const ctx = createScanContext({ url: "https://guard.test", fetchImpl });
+    const result = await checkWebMcp(ctx);
+    expect(result.status).toBe("fail");
+    // Protocol-relative URL resolves to https://cdn.evil.com/x.js — must skip.
+    expect(calls.some((u) => u.startsWith("https://cdn.evil.com/"))).toBe(
+      false,
+    );
+    const skipStep = result.evidence.find((s) =>
+      s.finding.summary.toLowerCase().includes("cross-origin"),
     );
     expect(skipStep).toBeDefined();
   });
@@ -304,8 +308,13 @@ describe("webMcp — fail paths", () => {
     const ctx = createScanContext({ url: "https://many.test", fetchImpl });
     const result = await checkWebMcp(ctx);
     expect(result.status).toBe("fail");
-    // Homepage + at most 20 scripts fetched (implementation cap).
-    expect(calls.length).toBeLessThanOrEqual(21);
+    // Exactly 20 script fetches (the implementation cap) — no more, no fewer.
+    const scriptCalls = calls.filter((u) => /\/s\d+\.js$/.test(u));
+    expect(scriptCalls).toHaveLength(20);
+    // Negative assertion: scripts s20..s24 must never be fetched.
+    for (let i = 20; i < 25; i++) {
+      expect(calls.some((u) => u.endsWith(`/s${i}.js`))).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
Tracks task #3. Owned: impl-D. Files: lib/engine/checks/{a2a-agent-card,agent-skills,web-mcp}.ts + specs. webMcp uses static-HTML+regex fallback (no Chromium; upgrade path = Vercel Sandbox). TDD + 3 iterations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added discovery check for A2A agent card detection via `/.well-known/agent-card.json` endpoint
  * Added discovery check for agent skills detection with v0.2.0 and legacy fallback support
  * Added static detection for WebMCP capability via script and API pattern scanning

* **Tests**
  * Added comprehensive test coverage for all three new discovery checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->