### PR TITLE
Phase 2 — commerce checks (isCommerce helper + x402, mpp, ucp, acp, ap2)

### DIFF
--- a/lib/engine/checks/acp.ts
+++ b/lib/engine/checks/acp.ts
@@ -1,0 +1,173 @@
+/**
+ * Commerce check: `acp` (Agentic Commerce Protocol).
+ *
+ * Reference: FINDINGS §3 + §9. Spec: https://agenticcommerce.dev/.
+ *
+ * Fetch plan: `GET /.well-known/acp.json`.
+ * Pass criteria:
+ *   - response is 200, AND
+ *   - body parses as JSON, AND
+ *   - `protocol.name === "acp"`, AND
+ *   - `api_base_url` is present (truthy string), AND
+ *   - `transports[]` is a non-empty array, AND
+ *   - `capabilities.services[]` is a non-empty array.
+ */
+
+import {
+  fetchToStep,
+  makeStep,
+  type ScanContext,
+  type FetchOutcome,
+} from "@/lib/engine/context";
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import { applyCommerceGate } from "@/lib/engine/commerce-signals";
+
+const FETCH_LABEL = "GET /.well-known/acp.json";
+const CONCLUDE_LABEL = "Conclusion";
+
+const PASS_MESSAGE = "ACP discovery document found";
+const FAIL_MESSAGE = "ACP discovery document not found";
+
+interface Options {
+  readonly isCommerce: boolean;
+}
+
+function isNonEmptyArray(v: unknown): boolean {
+  return Array.isArray(v) && v.length > 0;
+}
+
+function evaluate(outcome: FetchOutcome): {
+  pass: boolean;
+  summary: string;
+  verdict: "positive" | "negative";
+} {
+  if (outcome.response === undefined) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: `ACP request failed: ${outcome.error ?? "no response"}`,
+    };
+  }
+  const status = outcome.response.status;
+  if (status !== 200) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: `Server returned ${status} -- ACP discovery document not found`,
+    };
+  }
+  const body = outcome.body ?? "";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: "ACP discovery response is not valid JSON",
+    };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: "ACP discovery body is not a JSON object",
+    };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const protocol = obj["protocol"];
+  const protocolName =
+    protocol !== null && typeof protocol === "object"
+      ? (protocol as Record<string, unknown>)["name"]
+      : undefined;
+  if (protocolName !== "acp") {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: `ACP protocol.name is not "acp"`,
+    };
+  }
+  const apiBase = obj["api_base_url"];
+  if (typeof apiBase !== "string" || apiBase.length === 0) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: "ACP discovery missing api_base_url",
+    };
+  }
+  if (!isNonEmptyArray(obj["transports"])) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: "ACP discovery has no transports",
+    };
+  }
+  const capabilities = obj["capabilities"];
+  const services =
+    capabilities !== null && typeof capabilities === "object"
+      ? (capabilities as Record<string, unknown>)["services"]
+      : undefined;
+  if (!isNonEmptyArray(services)) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: "ACP discovery has no capabilities.services",
+    };
+  }
+  return {
+    pass: true,
+    verdict: "positive",
+    summary: "ACP discovery document is valid",
+  };
+}
+
+export async function checkAcp(
+  ctx: ScanContext,
+  opts: Options,
+): Promise<CheckResult> {
+  const started = Date.now();
+  const outcome = await ctx.fetch("/.well-known/acp.json");
+  const verdict = evaluate(outcome);
+
+  const evidence: EvidenceStep[] = [];
+  evidence.push(
+    fetchToStep(outcome, FETCH_LABEL, {
+      outcome: verdict.verdict,
+      summary: verdict.summary,
+    }),
+  );
+
+  if (verdict.pass) {
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "positive",
+        summary: PASS_MESSAGE,
+      }),
+    );
+    return applyCommerceGate(
+      {
+        status: "pass",
+        message: PASS_MESSAGE,
+        evidence,
+        durationMs: Date.now() - started,
+      },
+      opts.isCommerce,
+    );
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "negative",
+      summary: FAIL_MESSAGE,
+    }),
+  );
+  return applyCommerceGate(
+    {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    },
+    opts.isCommerce,
+  );
+}

--- a/lib/engine/checks/ap2.ts
+++ b/lib/engine/checks/ap2.ts
@@ -45,18 +45,18 @@ const PASS_SUMMARY =
 /**
  * AP2-compatible skill tokens. Any A2A Agent Card skill id (or key) that
  * contains one of these substrings (case-insensitive) counts as AP2
- * advertisement. The list errs on the side of inclusion: AP2 draft doesn't
- * mandate an exact id yet, so we accept obvious payment-commerce tokens plus
- * the literal "ap2" prefix. This mirrors the "derived from A2A Agent Card
- * presence" rule in FINDINGS §3.
+ * advertisement. We intentionally keep this list tight — AP2 draft doesn't
+ * mandate an exact id yet, but broader tokens like "commerce" or "purchase"
+ * over-match skills such as "commerce-reports" or unrelated commerce tooling.
+ * The literal "ap2" prefix plus "payment(s)" and "checkout" are specific
+ * enough to minimise false positives while still catching the obvious
+ * advertisements FINDINGS §3 describes.
  */
 const AP2_SKILL_TOKENS = [
   "ap2",
   "payment",
   "payments",
   "checkout",
-  "commerce",
-  "purchase",
 ] as const;
 
 interface Options {

--- a/lib/engine/checks/ap2.ts
+++ b/lib/engine/checks/ap2.ts
@@ -1,0 +1,174 @@
+/**
+ * Commerce check: `ap2` (Agent Payments Protocol v2).
+ *
+ * Reference: FINDINGS §3 + §9 + §13 (Gap #5). AP2 has no public SKILL.md;
+ * the reference scanner derives its verdict entirely from the A2A Agent
+ * Card result — AP2 is "present" iff the A2A Agent Card passes AND declares
+ * an AP2-compatible skill.
+ *
+ * Dependency wiring — Option A (per impl-E instructions)
+ * -------------------------------------------------------
+ * To avoid a file-ownership circular dependency between this check
+ * (owned by impl-E) and `a2a-agent-card.ts` (owned by impl-C), we accept
+ * the prior check's `CheckResult` as a function parameter. The orchestrator
+ * (Phase 3) is responsible for running `a2aAgentCard` first and passing
+ * its result in. `null` is accepted (e.g. when the user has opted out of
+ * the a2a check, or when the orchestrator has not yet been wired) — in
+ * that case AP2 reports the same "no A2A Agent Card" verdict as a failing
+ * a2a result, matching both shopify and vercel oracles which record an
+ * absent card.
+ *
+ * Commerce gating mirrors the other commerce checks: when `isCommerce` is
+ * false, the top-level status is forced to "neutral" and
+ * " (not a commerce site)" is appended to the message. The inner evidence
+ * and conclusion finding are preserved verbatim.
+ */
+
+import { makeStep } from "@/lib/engine/context";
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import { applyCommerceGate } from "@/lib/engine/commerce-signals";
+
+const CONCLUDE_LABEL = "Conclusion";
+
+const FAIL_MESSAGE = "AP2 not detected (no A2A Agent Card)";
+const FAIL_NO_CARD_SUMMARY =
+  "No A2A Agent Card found -- AP2 requires an A2A Agent Card";
+
+const FAIL_NO_SKILL_MESSAGE = "AP2 not detected (no AP2-compatible skill)";
+const FAIL_NO_SKILL_SUMMARY =
+  "A2A Agent Card found but no AP2-compatible skill declared";
+
+const PASS_MESSAGE = "AP2 detected via A2A Agent Card";
+const PASS_SUMMARY =
+  "A2A Agent Card declares an AP2-compatible skill";
+
+/**
+ * AP2-compatible skill tokens. Any A2A Agent Card skill id (or key) that
+ * contains one of these substrings (case-insensitive) counts as AP2
+ * advertisement. The list errs on the side of inclusion: AP2 draft doesn't
+ * mandate an exact id yet, so we accept obvious payment-commerce tokens plus
+ * the literal "ap2" prefix. This mirrors the "derived from A2A Agent Card
+ * presence" rule in FINDINGS §3.
+ */
+const AP2_SKILL_TOKENS = [
+  "ap2",
+  "payment",
+  "payments",
+  "checkout",
+  "commerce",
+  "purchase",
+] as const;
+
+interface Options {
+  readonly isCommerce: boolean;
+  /**
+   * Result of the `a2aAgentCard` check from the same scan. Nullable to
+   * accommodate callers (orchestrator, tests) that haven't yet computed
+   * it — treated as "no card present".
+   */
+  readonly a2aAgentCard: CheckResult | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SkillLike {
+  readonly id?: unknown;
+  readonly name?: unknown;
+  readonly key?: unknown;
+}
+
+function extractSkillTokens(details: unknown): string[] {
+  if (details === null || typeof details !== "object") return [];
+  const obj = details as Record<string, unknown>;
+  const skills = obj["skills"];
+  if (!Array.isArray(skills)) return [];
+  const tokens: string[] = [];
+  for (const skill of skills) {
+    if (typeof skill === "string") {
+      tokens.push(skill.toLowerCase());
+      continue;
+    }
+    if (skill !== null && typeof skill === "object") {
+      const s = skill as SkillLike;
+      for (const cand of [s.id, s.name, s.key]) {
+        if (typeof cand === "string") tokens.push(cand.toLowerCase());
+      }
+    }
+  }
+  return tokens;
+}
+
+function hasAp2Skill(tokens: readonly string[]): boolean {
+  for (const token of tokens) {
+    for (const ap2 of AP2_SKILL_TOKENS) {
+      if (token.includes(ap2)) return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkAp2(opts: Options): Promise<CheckResult> {
+  const started = Date.now();
+
+  const a2a = opts.a2aAgentCard;
+  const cardMissing = a2a === null || a2a.status !== "pass";
+
+  if (cardMissing) {
+    const evidence: EvidenceStep[] = [
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_NO_CARD_SUMMARY,
+      }),
+    ];
+    return applyCommerceGate(
+      {
+        status: "fail",
+        message: FAIL_MESSAGE,
+        evidence,
+        durationMs: Date.now() - started,
+      },
+      opts.isCommerce,
+    );
+  }
+
+  const tokens = extractSkillTokens(a2a.details);
+  if (!hasAp2Skill(tokens)) {
+    const evidence: EvidenceStep[] = [
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "negative",
+        summary: FAIL_NO_SKILL_SUMMARY,
+      }),
+    ];
+    return applyCommerceGate(
+      {
+        status: "fail",
+        message: FAIL_NO_SKILL_MESSAGE,
+        evidence,
+        durationMs: Date.now() - started,
+      },
+      opts.isCommerce,
+    );
+  }
+
+  const evidence: EvidenceStep[] = [
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "positive",
+      summary: PASS_SUMMARY,
+    }),
+  ];
+  return applyCommerceGate(
+    {
+      status: "pass",
+      message: PASS_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    },
+    opts.isCommerce,
+  );
+}

--- a/lib/engine/checks/mpp.ts
+++ b/lib/engine/checks/mpp.ts
@@ -1,0 +1,153 @@
+/**
+ * Commerce check: `mpp` (Machine Payment Protocol).
+ *
+ * Reference: FINDINGS §3 + §9. Spec: https://mpp.dev/.
+ *
+ * Fetch plan: `GET /openapi.json`.
+ * Pass iff:
+ *   - response is 200, AND
+ *   - body parses as JSON, AND
+ *   - body contains an `x-payment-info` extension key anywhere — either at
+ *     the root of the OpenAPI document or nested inside operations.
+ *
+ * HTML soft-404 responses (200 + `content-type: text/html`) fail with a
+ * distinct summary matching the fixture oracle verbatim.
+ */
+
+import {
+  fetchToStep,
+  makeStep,
+  type ScanContext,
+  type FetchOutcome,
+} from "@/lib/engine/context";
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import { applyCommerceGate } from "@/lib/engine/commerce-signals";
+
+const FETCH_LABEL = "GET /openapi.json";
+const CONCLUDE_LABEL = "Conclusion";
+
+const PASS_MESSAGE = "MPP payment discovery detected";
+const FAIL_MESSAGE = "MPP payment discovery not detected";
+
+interface Options {
+  readonly isCommerce: boolean;
+}
+
+function containsKeyDeep(value: unknown, key: string): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (containsKeyDeep(item, key)) return true;
+    }
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  if (Object.prototype.hasOwnProperty.call(obj, key)) return true;
+  for (const v of Object.values(obj)) {
+    if (containsKeyDeep(v, key)) return true;
+  }
+  return false;
+}
+
+function evaluate(outcome: FetchOutcome): {
+  pass: boolean;
+  summary: string;
+  verdict: "positive" | "neutral" | "negative";
+} {
+  if (outcome.response === undefined) {
+    return {
+      pass: false,
+      verdict: "neutral",
+      summary: `/openapi.json request failed: ${outcome.error ?? "no response"}`,
+    };
+  }
+  const status = outcome.response.status;
+  const contentType = outcome.response.headers["content-type"] ?? "";
+  if (status !== 200) {
+    return {
+      pass: false,
+      verdict: "neutral",
+      summary: `/openapi.json returned ${status}`,
+    };
+  }
+  if (contentType.includes("text/html")) {
+    return {
+      pass: false,
+      verdict: "neutral",
+      summary: "/openapi.json returned HTML (likely soft-404)",
+    };
+  }
+  const body = outcome.body ?? "";
+  try {
+    const parsed = JSON.parse(body);
+    if (containsKeyDeep(parsed, "x-payment-info")) {
+      return {
+        pass: true,
+        verdict: "positive",
+        summary: "/openapi.json declares x-payment-info",
+      };
+    }
+    return {
+      pass: false,
+      verdict: "neutral",
+      summary: "/openapi.json has no x-payment-info extension",
+    };
+  } catch {
+    return {
+      pass: false,
+      verdict: "neutral",
+      summary: "/openapi.json response is not valid JSON",
+    };
+  }
+}
+
+export async function checkMpp(
+  ctx: ScanContext,
+  opts: Options,
+): Promise<CheckResult> {
+  const started = Date.now();
+  const outcome = await ctx.fetch("/openapi.json");
+  const verdict = evaluate(outcome);
+
+  const evidence: EvidenceStep[] = [];
+  evidence.push(
+    fetchToStep(outcome, FETCH_LABEL, {
+      outcome: verdict.verdict,
+      summary: verdict.summary,
+    }),
+  );
+
+  if (verdict.pass) {
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "positive",
+        summary: PASS_MESSAGE,
+      }),
+    );
+    return applyCommerceGate(
+      {
+        status: "pass",
+        message: PASS_MESSAGE,
+        evidence,
+        durationMs: Date.now() - started,
+      },
+      opts.isCommerce,
+    );
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "negative",
+      summary: FAIL_MESSAGE,
+    }),
+  );
+  return applyCommerceGate(
+    {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    },
+    opts.isCommerce,
+  );
+}

--- a/lib/engine/checks/ucp.ts
+++ b/lib/engine/checks/ucp.ts
@@ -1,0 +1,144 @@
+/**
+ * Commerce check: `ucp` (Universal Commerce Protocol).
+ *
+ * Reference: FINDINGS §3 + §9. Spec: https://ucp.dev/.
+ *
+ * Fetch plan: `GET /.well-known/ucp`.
+ * Pass iff 200 + JSON body containing all four required fields:
+ *   - `protocol_version`
+ *   - `services`
+ *   - `capabilities`
+ *   - `endpoints`
+ */
+
+import {
+  fetchToStep,
+  makeStep,
+  type ScanContext,
+  type FetchOutcome,
+} from "@/lib/engine/context";
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import { applyCommerceGate } from "@/lib/engine/commerce-signals";
+
+const FETCH_LABEL = "GET /.well-known/ucp";
+const CONCLUDE_LABEL = "Conclusion";
+
+const PASS_MESSAGE = "UCP profile found";
+const FAIL_MESSAGE = "UCP profile not found";
+
+const REQUIRED_FIELDS = [
+  "protocol_version",
+  "services",
+  "capabilities",
+  "endpoints",
+] as const;
+
+interface Options {
+  readonly isCommerce: boolean;
+}
+
+function evaluate(outcome: FetchOutcome): {
+  pass: boolean;
+  summary: string;
+  verdict: "positive" | "negative";
+} {
+  if (outcome.response === undefined) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: `UCP request failed: ${outcome.error ?? "no response"}`,
+    };
+  }
+  const status = outcome.response.status;
+  if (status !== 200) {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: `Server returned ${status} -- UCP profile not found`,
+    };
+  }
+  const body = outcome.body ?? "";
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {
+        pass: false,
+        verdict: "negative",
+        summary: "UCP profile body is not a JSON object",
+      };
+    }
+    const obj = parsed as Record<string, unknown>;
+    const missing = REQUIRED_FIELDS.filter(
+      (f) => !Object.prototype.hasOwnProperty.call(obj, f),
+    );
+    if (missing.length > 0) {
+      return {
+        pass: false,
+        verdict: "negative",
+        summary: `UCP profile missing required field(s): ${missing.join(", ")}`,
+      };
+    }
+    return {
+      pass: true,
+      verdict: "positive",
+      summary: "UCP profile contains all required fields",
+    };
+  } catch {
+    return {
+      pass: false,
+      verdict: "negative",
+      summary: "UCP profile response is not valid JSON",
+    };
+  }
+}
+
+export async function checkUcp(
+  ctx: ScanContext,
+  opts: Options,
+): Promise<CheckResult> {
+  const started = Date.now();
+  const outcome = await ctx.fetch("/.well-known/ucp");
+  const verdict = evaluate(outcome);
+
+  const evidence: EvidenceStep[] = [];
+  evidence.push(
+    fetchToStep(outcome, FETCH_LABEL, {
+      outcome: verdict.verdict,
+      summary: verdict.summary,
+    }),
+  );
+
+  if (verdict.pass) {
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "positive",
+        summary: PASS_MESSAGE,
+      }),
+    );
+    return applyCommerceGate(
+      {
+        status: "pass",
+        message: PASS_MESSAGE,
+        evidence,
+        durationMs: Date.now() - started,
+      },
+      opts.isCommerce,
+    );
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "negative",
+      summary: FAIL_MESSAGE,
+    }),
+  );
+  return applyCommerceGate(
+    {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    },
+    opts.isCommerce,
+  );
+}

--- a/lib/engine/checks/x402.ts
+++ b/lib/engine/checks/x402.ts
@@ -136,18 +136,23 @@ function normaliseHost(h: string): string {
  * we compare the normalised bare hosts directly so a candidate like
  * `a.com:8443` still matches `a.com` / `a.com:8443`.
  *
- * `URL` construction for a well-formed `https://<host>` input effectively
- * never throws, so we deliberately do not wrap it in try/catch — a bare-host
- * fallback covers the no-scheme case explicitly.
+ * Bazaar payloads are attacker-influenced: a malformed scheme-ish candidate
+ * like `"ht!tp://nonsense"` will cause `new URL(...)` to throw. We defensively
+ * wrap URL construction and treat parse failures as a non-match so a single
+ * bad entry cannot abort the scan loop.
  */
 function hostMatches(candidate: string, expected: string): boolean {
-  const exp = normaliseHost(expected);
+  const normalisedExpected = normaliseHost(expected);
   if (candidate.includes("://")) {
-    const u = new URL(candidate);
-    // `u.hostname` strips the port; normalise trailing-dot only.
-    return normaliseHost(u.hostname) === exp;
+    try {
+      const u = new URL(candidate);
+      // `u.hostname` strips the port; normalise trailing-dot only.
+      return normaliseHost(u.hostname) === normalisedExpected;
+    } catch {
+      return false;
+    }
   }
-  return normaliseHost(candidate) === exp;
+  return normaliseHost(candidate) === normalisedExpected;
 }
 
 function bazaarMatchesHost(body: string, host: string): boolean {

--- a/lib/engine/checks/x402.ts
+++ b/lib/engine/checks/x402.ts
@@ -1,0 +1,220 @@
+/**
+ * Commerce check: `x402`.
+ *
+ * Reference: FINDINGS §3 + §9. Spec: https://www.x402.org/.
+ *
+ * Fetch plan (matches the reference scanner's evidence shape):
+ *   1. `GET /`                                        — home probe, looking for 402
+ *   2. `GET /platform/v2/x402/discovery/resources`    — x402 bazaar (coinbase)
+ *   3. `GET /api`                                     — common API root
+ *   4. `GET /api/v1`                                  — common versioned API root
+ *
+ * Pass criteria: ANY of the origin probes (1, 3, 4) returns status 402 with
+ * an x402 payment requirements body, OR the origin appears in the bazaar
+ * response data[].
+ *
+ * Commerce gating: when `isCommerce === false`, the final `status` is
+ * forced to "neutral" and " (not a commerce site)" is appended to the
+ * message. Evidence and detail payloads are preserved verbatim so the
+ * audit view still shows what was probed.
+ */
+
+import {
+  fetchToStep,
+  makeStep,
+  type ScanContext,
+  type FetchOutcome,
+} from "@/lib/engine/context";
+import type { CheckResult, EvidenceStep } from "@/lib/schema";
+import { applyCommerceGate } from "@/lib/engine/commerce-signals";
+
+export const X402_BAZAAR_URL =
+  "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500";
+
+const CONCLUDE_LABEL = "Conclusion";
+const FAIL_MESSAGE = "x402 payment protocol not detected";
+const PASS_MESSAGE = "x402 payment protocol detected";
+
+interface Options {
+  readonly isCommerce: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function probeFinding(
+  label: string,
+  outcome: FetchOutcome,
+): { outcome: "positive" | "neutral" | "negative"; summary: string } {
+  if (outcome.response === undefined) {
+    return {
+      outcome: "neutral",
+      summary: `${label} request failed: ${outcome.error ?? "no response"}`,
+    };
+  }
+  const status = outcome.response.status;
+  if (status === 402) {
+    return {
+      outcome: "positive",
+      summary: `${label} returned 402 (x402 payment required)`,
+    };
+  }
+  return {
+    outcome: "neutral",
+    summary: `${label} returned ${status} (not 402)`,
+  };
+}
+
+function originHost(ctx: ScanContext): string {
+  return ctx.url.host;
+}
+
+interface BazaarEntry {
+  readonly origin?: unknown;
+  readonly host?: unknown;
+  readonly url?: unknown;
+  readonly resource?: unknown;
+}
+
+function bazaarMatchesHost(body: string, host: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    const container =
+      parsed !== null && typeof parsed === "object"
+        ? (parsed as { data?: unknown; resources?: unknown })
+        : {};
+    const entries: BazaarEntry[] = Array.isArray(container.data)
+      ? (container.data as BazaarEntry[])
+      : Array.isArray(container.resources)
+        ? (container.resources as BazaarEntry[])
+        : Array.isArray(parsed)
+          ? (parsed as BazaarEntry[])
+          : [];
+    const lcHost = host.toLowerCase();
+    for (const entry of entries) {
+      const candidates = [entry.origin, entry.host, entry.url, entry.resource];
+      for (const c of candidates) {
+        if (typeof c === "string" && c.toLowerCase().includes(lcHost)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function bazaarCount(body: string): number {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed !== null && typeof parsed === "object") {
+      const container = parsed as { data?: unknown; resources?: unknown };
+      if (Array.isArray(container.data)) return container.data.length;
+      if (Array.isArray(container.resources)) return container.resources.length;
+    }
+    if (Array.isArray(parsed)) return parsed.length;
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function checkX402(
+  ctx: ScanContext,
+  opts: Options,
+): Promise<CheckResult> {
+  const started = Date.now();
+
+  // Fetch all four probes in parallel.
+  const [homeOutcome, bazaarOutcome, apiOutcome, apiV1Outcome] =
+    await Promise.all([
+      ctx.getHomepage(),
+      ctx.fetch(X402_BAZAAR_URL),
+      ctx.fetch("/api"),
+      ctx.fetch("/api/v1"),
+    ]);
+
+  const evidence: EvidenceStep[] = [];
+  let pass = false;
+
+  // 1) Homepage
+  const homeFinding = probeFinding("/", homeOutcome);
+  if (homeFinding.outcome === "positive") pass = true;
+  evidence.push(fetchToStep(homeOutcome, "GET /", homeFinding));
+
+  // 2) Bazaar
+  const host = originHost(ctx);
+  let bazaarSummary: string;
+  let bazaarOutcomeVerdict: "positive" | "neutral" | "negative" = "neutral";
+  if (bazaarOutcome.response === undefined) {
+    bazaarSummary = `Bazaar API request failed: ${bazaarOutcome.error ?? "no response"}`;
+  } else if (bazaarOutcome.response.status !== 200) {
+    bazaarSummary = `Bazaar API returned ${bazaarOutcome.response.status}`;
+  } else {
+    const body = bazaarOutcome.body ?? "";
+    const count = bazaarCount(body);
+    if (bazaarMatchesHost(body, host)) {
+      pass = true;
+      bazaarOutcomeVerdict = "positive";
+      bazaarSummary = `Bazaar API returned ${count} entries, matched ${host}`;
+    } else {
+      bazaarSummary = `Bazaar API returned ${count} entries, none matching ${host}`;
+    }
+  }
+  evidence.push(
+    fetchToStep(bazaarOutcome, "GET /platform/v2/x402/discovery/resources", {
+      outcome: bazaarOutcomeVerdict,
+      summary: bazaarSummary,
+    }),
+  );
+
+  // 3) /api
+  const apiFinding = probeFinding("/api", apiOutcome);
+  if (apiFinding.outcome === "positive") pass = true;
+  evidence.push(fetchToStep(apiOutcome, "GET /api", apiFinding));
+
+  // 4) /api/v1
+  const apiV1Finding = probeFinding("/api/v1", apiV1Outcome);
+  if (apiV1Finding.outcome === "positive") pass = true;
+  evidence.push(fetchToStep(apiV1Outcome, "GET /api/v1", apiV1Finding));
+
+  if (pass) {
+    evidence.push(
+      makeStep("conclude", CONCLUDE_LABEL, {
+        outcome: "positive",
+        summary: PASS_MESSAGE,
+      }),
+    );
+    return applyCommerceGate(
+      {
+        status: "pass",
+        message: PASS_MESSAGE,
+        evidence,
+        durationMs: Date.now() - started,
+      },
+      opts.isCommerce,
+    );
+  }
+
+  evidence.push(
+    makeStep("conclude", CONCLUDE_LABEL, {
+      outcome: "negative",
+      summary: FAIL_MESSAGE,
+    }),
+  );
+  return applyCommerceGate(
+    {
+      status: "fail",
+      message: FAIL_MESSAGE,
+      evidence,
+      durationMs: Date.now() - started,
+    },
+    opts.isCommerce,
+  );
+}

--- a/lib/engine/checks/x402.ts
+++ b/lib/engine/checks/x402.ts
@@ -43,6 +43,27 @@ interface Options {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Verify that a 402 response body looks like x402 payment requirements.
+ * A stray 402 (e.g. a Stripe-style error envelope) must not count. The
+ * x402 protocol mandates either `x402Version` at the root or an
+ * `accepts[]` array of payment requirements — checking for either is
+ * sufficient to distinguish genuine x402 from coincidental 402 usage.
+ */
+function isX402Body(body: string | undefined): boolean {
+  if (body === undefined || body.length === 0) return false;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed === null || typeof parsed !== "object") return false;
+    const obj = parsed as Record<string, unknown>;
+    if (obj["x402Version"] !== undefined) return true;
+    if (Array.isArray(obj["accepts"])) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 function probeFinding(
   label: string,
   outcome: FetchOutcome,
@@ -55,9 +76,15 @@ function probeFinding(
   }
   const status = outcome.response.status;
   if (status === 402) {
+    if (isX402Body(outcome.body)) {
+      return {
+        outcome: "positive",
+        summary: `${label} returned 402 (x402 payment required)`,
+      };
+    }
     return {
-      outcome: "positive",
-      summary: `${label} returned 402 (x402 payment required)`,
+      outcome: "neutral",
+      summary: `${label} returned 402 but body is not an x402 payment requirements document`,
     };
   }
   return {
@@ -66,15 +93,30 @@ function probeFinding(
   };
 }
 
-function originHost(ctx: ScanContext): string {
-  return ctx.url.host;
-}
-
 interface BazaarEntry {
   readonly origin?: unknown;
   readonly host?: unknown;
   readonly url?: unknown;
   readonly resource?: unknown;
+}
+
+/**
+ * Compare a bazaar candidate string to the expected host using exact hostname
+ * equality (case-insensitive). We previously used substring matching, which is
+ * vulnerable to host-confusion: a scan of `a.com` would match a bazaar entry
+ * for `a.com.evil.test`. Parsing as a URL and comparing `hostname` exactly
+ * closes that attack surface. If the candidate is a bare host (no scheme),
+ * we fall back to direct string comparison.
+ */
+function hostMatches(candidate: string, expected: string): boolean {
+  try {
+    const u = new URL(
+      candidate.includes("://") ? candidate : `https://${candidate}`,
+    );
+    return u.hostname.toLowerCase() === expected.toLowerCase();
+  } catch {
+    return candidate.toLowerCase() === expected.toLowerCase();
+  }
 }
 
 function bazaarMatchesHost(body: string, host: string): boolean {
@@ -91,11 +133,10 @@ function bazaarMatchesHost(body: string, host: string): boolean {
         : Array.isArray(parsed)
           ? (parsed as BazaarEntry[])
           : [];
-    const lcHost = host.toLowerCase();
     for (const entry of entries) {
       const candidates = [entry.origin, entry.host, entry.url, entry.resource];
       for (const c of candidates) {
-        if (typeof c === "string" && c.toLowerCase().includes(lcHost)) {
+        if (typeof c === "string" && hostMatches(c, host)) {
           return true;
         }
       }
@@ -149,7 +190,7 @@ export async function checkX402(
   evidence.push(fetchToStep(homeOutcome, "GET /", homeFinding));
 
   // 2) Bazaar
-  const host = originHost(ctx);
+  const host = ctx.url.host;
   let bazaarSummary: string;
   let bazaarOutcomeVerdict: "positive" | "neutral" | "negative" = "neutral";
   if (bazaarOutcome.response === undefined) {

--- a/lib/engine/checks/x402.ts
+++ b/lib/engine/checks/x402.ts
@@ -47,8 +47,12 @@ interface Options {
  * Verify that a 402 response body looks like x402 payment requirements.
  * A stray 402 (e.g. a Stripe-style error envelope) must not count. The
  * x402 protocol mandates either `x402Version` at the root or an
- * `accepts[]` array of payment requirements — checking for either is
- * sufficient to distinguish genuine x402 from coincidental 402 usage.
+ * `accepts[]` array of payment requirements.
+ *
+ * We require EITHER a typed `x402Version` (string or number) OR a
+ * non-empty `accepts[]`. A bare `{accepts: []}` is rejected — an empty
+ * requirements list is not meaningful and overlaps with generic 402
+ * envelopes we've seen in the wild.
  */
 function isX402Body(body: string | undefined): boolean {
   if (body === undefined || body.length === 0) return false;
@@ -56,9 +60,12 @@ function isX402Body(body: string | undefined): boolean {
     const parsed: unknown = JSON.parse(body);
     if (parsed === null || typeof parsed !== "object") return false;
     const obj = parsed as Record<string, unknown>;
-    if (obj["x402Version"] !== undefined) return true;
-    if (Array.isArray(obj["accepts"])) return true;
-    return false;
+    const version = obj["x402Version"];
+    const hasVersion =
+      typeof version === "string" || typeof version === "number";
+    const accepts = obj["accepts"];
+    const acceptsNonEmpty = Array.isArray(accepts) && accepts.length > 0;
+    return hasVersion || acceptsNonEmpty;
   } catch {
     return false;
   }
@@ -101,22 +108,46 @@ interface BazaarEntry {
 }
 
 /**
+ * Normalise a host-ish string for comparison:
+ * - lowercase
+ * - strip a single trailing "." (root-zone FQDN form, e.g. `a.com.`)
+ * - strip a `:<port>` suffix (host vs hostname parity; bazaar entries may
+ *   include explicit non-default ports)
+ */
+function normaliseHost(h: string): string {
+  let out = h.toLowerCase();
+  if (out.endsWith(".")) out = out.slice(0, -1);
+  const colon = out.lastIndexOf(":");
+  if (colon !== -1) {
+    const port = out.slice(colon + 1);
+    if (port.length > 0 && /^\d+$/.test(port)) {
+      out = out.slice(0, colon);
+    }
+  }
+  return out;
+}
+
+/**
  * Compare a bazaar candidate string to the expected host using exact hostname
  * equality (case-insensitive). We previously used substring matching, which is
  * vulnerable to host-confusion: a scan of `a.com` would match a bazaar entry
  * for `a.com.evil.test`. Parsing as a URL and comparing `hostname` exactly
  * closes that attack surface. If the candidate is a bare host (no scheme),
- * we fall back to direct string comparison.
+ * we compare the normalised bare hosts directly so a candidate like
+ * `a.com:8443` still matches `a.com` / `a.com:8443`.
+ *
+ * `URL` construction for a well-formed `https://<host>` input effectively
+ * never throws, so we deliberately do not wrap it in try/catch — a bare-host
+ * fallback covers the no-scheme case explicitly.
  */
 function hostMatches(candidate: string, expected: string): boolean {
-  try {
-    const u = new URL(
-      candidate.includes("://") ? candidate : `https://${candidate}`,
-    );
-    return u.hostname.toLowerCase() === expected.toLowerCase();
-  } catch {
-    return candidate.toLowerCase() === expected.toLowerCase();
+  const exp = normaliseHost(expected);
+  if (candidate.includes("://")) {
+    const u = new URL(candidate);
+    // `u.hostname` strips the port; normalise trailing-dot only.
+    return normaliseHost(u.hostname) === exp;
   }
+  return normaliseHost(candidate) === exp;
 }
 
 function bazaarMatchesHost(body: string, host: string): boolean {
@@ -189,8 +220,10 @@ export async function checkX402(
   if (homeFinding.outcome === "positive") pass = true;
   evidence.push(fetchToStep(homeOutcome, "GET /", homeFinding));
 
-  // 2) Bazaar
-  const host = ctx.url.host;
+  // 2) Bazaar — compare against `hostname` (port-stripped). Using `host`
+  // (which includes an explicit port) would cause an origin like
+  // `example.com:8443` to miss bazaar entries recorded without a port.
+  const host = ctx.url.hostname;
   let bazaarSummary: string;
   let bazaarOutcomeVerdict: "positive" | "neutral" | "negative" = "neutral";
   if (bazaarOutcome.response === undefined) {

--- a/lib/engine/commerce-signals.ts
+++ b/lib/engine/commerce-signals.ts
@@ -130,11 +130,13 @@ const META_REGEXES: ReadonlyArray<{ signal: string; re: RegExp }> = [
 ];
 
 /**
- * Platform meta regexes. We deliberately scope matches to two narrow shapes
+ * Platform meta regexes. We deliberately scope matches to three narrow shapes
  * so unrelated descriptive copy doesn't trigger a false positive:
- *   1. `<meta name="generator" content="...shopify...">` (the conventional
- *      CMS/platform self-identification meta), or
- *   2. `<meta name="shopify...">` / `<meta name="woocommerce...">` etc. —
+ *   1. `<meta name="generator" content="...shopify...">` — the conventional
+ *      CMS/platform self-identification meta (name-first).
+ *   2. `<meta content="...shopify..." name="generator">` — the same meta
+ *      with reversed attribute order (valid per HTML; emitted by some CMSs).
+ *   3. `<meta name="shopify...">` / `<meta name="woocommerce...">` etc. —
  *      a platform-named meta tag.
  * A previous implementation matched any meta attribute value containing the
  * vendor token, which over-matched pages like
@@ -146,19 +148,19 @@ const PLATFORM_META_REGEXES: ReadonlyArray<{
 }> = [
   {
     id: "shopify",
-    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*shopify[^"']*["']|<meta\s+[^>]*name\s*=\s*["']shopify[^"']*["']/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*shopify[^"']*["']|<meta\s+[^>]*content\s*=\s*["'][^"']*shopify[^"']*["'][^>]*name\s*=\s*["']generator["']|<meta\s+[^>]*name\s*=\s*["']shopify[^"']*["']/i,
   },
   {
     id: "woocommerce",
-    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*woocommerce[^"']*["']|<meta\s+[^>]*name\s*=\s*["']woocommerce[^"']*["']/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*woocommerce[^"']*["']|<meta\s+[^>]*content\s*=\s*["'][^"']*woocommerce[^"']*["'][^>]*name\s*=\s*["']generator["']|<meta\s+[^>]*name\s*=\s*["']woocommerce[^"']*["']/i,
   },
   {
     id: "magento",
-    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*magento[^"']*["']|<meta\s+[^>]*name\s*=\s*["']magento[^"']*["']/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*magento[^"']*["']|<meta\s+[^>]*content\s*=\s*["'][^"']*magento[^"']*["'][^>]*name\s*=\s*["']generator["']|<meta\s+[^>]*name\s*=\s*["']magento[^"']*["']/i,
   },
   {
     id: "bigcommerce",
-    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*bigcommerce[^"']*["']|<meta\s+[^>]*name\s*=\s*["']bigcommerce[^"']*["']/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*bigcommerce[^"']*["']|<meta\s+[^>]*content\s*=\s*["'][^"']*bigcommerce[^"']*["'][^>]*name\s*=\s*["']generator["']|<meta\s+[^>]*name\s*=\s*["']bigcommerce[^"']*["']/i,
   },
 ];
 

--- a/lib/engine/commerce-signals.ts
+++ b/lib/engine/commerce-signals.ts
@@ -1,0 +1,253 @@
+/**
+ * Commerce signal heuristic.
+ *
+ * Reference: FINDINGS §3 (check category visibility rule) and §9 ("Commerce
+ * site detection"). Produces the top-level `isCommerce` / `commerceSignals`
+ * fields of the scan response.
+ *
+ * Signal vocabulary (order-insensitive):
+ *   - `platform:<vendor>` — one of `shopify`, `woocommerce`, `magento`,
+ *     `bigcommerce`. Detected from HTML body (generator meta, inline script
+ *     URLs) or response headers (`x-shopify-*`, `x-magento-*`, `x-powered-by`).
+ *   - `meta:<token>` — HTML declares `<meta name="product">`,
+ *     `<meta property="og:type" content="product">`, or a platform-named meta
+ *     (shopify/etc.).
+ *   - `url:/checkout | /product | /shop | /cart` — HEAD probe returns 200.
+ *
+ * `isCommerce` is true iff at least one signal is detected.
+ *
+ * Design notes:
+ * - Homepage probe is fetched via `ctx.getHomepage()` (shared with
+ *   `linkHeaders`, `webMcp`, `markdownNegotiation`). No extra round-trips.
+ * - Path HEAD probes are issued concurrently. Per-probe failures are
+ *   tolerated — a transport error on `/product` must not suppress a
+ *   200 on `/checkout`.
+ * - Immutable: the returned object is a fresh record; the helper never
+ *   mutates ctx state or any input.
+ */
+
+import type { ScanContext } from "@/lib/engine/context";
+import type { CheckResult } from "@/lib/schema";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CommerceSignalResult {
+  readonly isCommerce: boolean;
+  readonly commerceSignals: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Commerce gate (shared with commerce checks)
+// ---------------------------------------------------------------------------
+
+const NOT_COMMERCE_SUFFIX = " (not a commerce site)";
+
+/**
+ * Transform a commerce-check result based on `isCommerce`. When the site is
+ * not a commerce site, we force the status to "neutral" (excluding the check
+ * from the scoring denominator per FINDINGS §5) and append a diagnostic
+ * suffix to the message so the UI can explain why. Evidence, details, and
+ * durationMs are preserved verbatim — the audit view still shows exactly
+ * what was probed.
+ *
+ * Shared here (rather than in a separate helper file) because commerce-signals
+ * owns the concept of "commerce-ness" and the gate must stay in sync with the
+ * detector. Every commerce check in `checks/` re-exports this via its own
+ * import path.
+ */
+export function applyCommerceGate(
+  result: CheckResult,
+  isCommerce: boolean,
+): CheckResult {
+  if (isCommerce) return result;
+  return {
+    ...result,
+    status: "neutral",
+    message: result.message + NOT_COMMERCE_SUFFIX,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Platform heuristics
+// ---------------------------------------------------------------------------
+
+interface PlatformRule {
+  readonly id: "shopify" | "woocommerce" | "magento" | "bigcommerce";
+  /** Test the lowercase homepage body. */
+  readonly bodyTokens: readonly string[];
+  /** Response headers whose presence indicates the platform. */
+  readonly headerNames: readonly string[];
+  /** Substring checks against every response header VALUE. */
+  readonly headerValues: readonly string[];
+}
+
+const PLATFORM_RULES: readonly PlatformRule[] = [
+  {
+    id: "shopify",
+    bodyTokens: [
+      'content="shopify',
+      "cdn.shopify.com",
+      "shopifycloud",
+      "myshopify.com",
+    ],
+    headerNames: ["x-shopify-stage", "x-shopid", "x-shardid"],
+    headerValues: [],
+  },
+  {
+    id: "woocommerce",
+    bodyTokens: [
+      'content="woocommerce',
+      "/wp-content/plugins/woocommerce",
+      "wc-ajax",
+    ],
+    headerNames: ["x-wc-store-api-nonce"],
+    headerValues: ["woocommerce"],
+  },
+  {
+    id: "magento",
+    bodyTokens: [
+      'content="magento',
+      "/static/frontend/magento",
+      "mage-cache-storage",
+    ],
+    headerNames: ["x-magento-cache-debug", "x-magento-tags"],
+    headerValues: [],
+  },
+  {
+    id: "bigcommerce",
+    bodyTokens: ["cdn11.bigcommerce.com", 'content="bigcommerce'],
+    headerNames: ["x-bc-apigw-request-id"],
+    headerValues: ["bigcommerce"],
+  },
+] as const;
+
+const META_REGEXES: ReadonlyArray<{ signal: string; re: RegExp }> = [
+  // <meta name="product" ...> — generic product meta
+  { signal: "meta:product", re: /<meta\s+[^>]*name\s*=\s*["']product["'][^>]*>/i },
+  // <meta property="og:type" content="product">
+  {
+    signal: "meta:product",
+    re: /<meta\s+[^>]*property\s*=\s*["']og:type["'][^>]*content\s*=\s*["']product["'][^>]*>/i,
+  },
+];
+
+const PLATFORM_META_REGEXES: ReadonlyArray<{
+  id: PlatformRule["id"];
+  re: RegExp;
+}> = [
+  {
+    id: "shopify",
+    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*shopify[^"']*["'][^>]*>/i,
+  },
+  {
+    id: "woocommerce",
+    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*woocommerce[^"']*["'][^>]*>/i,
+  },
+  {
+    id: "magento",
+    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*magento[^"']*["'][^>]*>/i,
+  },
+  {
+    id: "bigcommerce",
+    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*bigcommerce[^"']*["'][^>]*>/i,
+  },
+];
+
+const URL_PROBES = [
+  "/checkout",
+  "/product",
+  "/shop",
+  "/cart",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Detectors
+// ---------------------------------------------------------------------------
+
+function detectPlatforms(
+  body: string,
+  headers: Record<string, string>,
+): Set<string> {
+  const found = new Set<string>();
+  const lower = body.toLowerCase();
+  for (const rule of PLATFORM_RULES) {
+    if (rule.bodyTokens.some((tok) => lower.includes(tok.toLowerCase()))) {
+      found.add(`platform:${rule.id}`);
+      continue;
+    }
+    if (rule.headerNames.some((h) => headers[h.toLowerCase()] !== undefined)) {
+      found.add(`platform:${rule.id}`);
+      continue;
+    }
+    if (rule.headerValues.length > 0) {
+      const joined = Object.values(headers).join(" ").toLowerCase();
+      if (rule.headerValues.some((v) => joined.includes(v.toLowerCase()))) {
+        found.add(`platform:${rule.id}`);
+      }
+    }
+  }
+  return found;
+}
+
+function detectMeta(body: string): Set<string> {
+  const found = new Set<string>();
+  for (const { signal, re } of META_REGEXES) {
+    if (re.test(body)) found.add(signal);
+  }
+  for (const { id, re } of PLATFORM_META_REGEXES) {
+    if (re.test(body)) found.add(`meta:${id}`);
+  }
+  return found;
+}
+
+async function detectUrlSignals(ctx: ScanContext): Promise<Set<string>> {
+  // Use GET (not HEAD) because some origins reject HEAD; pass a short
+  // timeout to avoid blocking the scan if a 404 path hangs.
+  const probes = URL_PROBES.map(async (path) => {
+    try {
+      const outcome = await ctx.fetch(path, { method: "HEAD" });
+      if (outcome.response !== undefined && outcome.response.status === 200) {
+        return `url:${path}`;
+      }
+    } catch {
+      // Swallow individual probe failures — conservative: no signal.
+    }
+    return undefined;
+  });
+  const resolved = await Promise.all(probes);
+  return new Set(resolved.filter((s): s is string => s !== undefined));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function detectCommerce(
+  ctx: ScanContext,
+): Promise<CommerceSignalResult> {
+  const [homepage, urlSignals] = await Promise.all([
+    ctx.getHomepage(),
+    detectUrlSignals(ctx),
+  ]);
+
+  const signals = new Set<string>();
+
+  if (homepage.response !== undefined) {
+    const body = homepage.body ?? "";
+    const headers = homepage.response.headers;
+    for (const s of detectPlatforms(body, headers)) signals.add(s);
+    for (const s of detectMeta(body)) signals.add(s);
+  }
+
+  for (const s of urlSignals) signals.add(s);
+
+  // Sorted for stable output — consumers can rely on order without
+  // callers having to sort themselves.
+  const commerceSignals = [...signals].sort();
+  return {
+    isCommerce: commerceSignals.length > 0,
+    commerceSignals,
+  };
+}

--- a/lib/engine/commerce-signals.ts
+++ b/lib/engine/commerce-signals.ts
@@ -62,10 +62,15 @@ export function applyCommerceGate(
   isCommerce: boolean,
 ): CheckResult {
   if (isCommerce) return result;
+  // Strip a single trailing period before appending the suffix so future
+  // messages ending in "." don't produce "foo. (not a commerce site)".
+  const base = result.message.endsWith(".")
+    ? result.message.slice(0, -1)
+    : result.message;
   return {
     ...result,
     status: "neutral",
-    message: result.message + NOT_COMMERCE_SUFFIX,
+    message: base + NOT_COMMERCE_SUFFIX,
   };
 }
 
@@ -83,41 +88,32 @@ interface PlatformRule {
   readonly headerValues: readonly string[];
 }
 
+// Body tokens are kept narrow — each token points at a platform-specific CDN,
+// plugin path, or internal script name. Descriptive copy like
+// `<meta name="description" content="shopify your store">` must NOT trigger a
+// platform match (see PLATFORM_META_REGEXES for the meta-tag route).
 const PLATFORM_RULES: readonly PlatformRule[] = [
   {
     id: "shopify",
-    bodyTokens: [
-      'content="shopify',
-      "cdn.shopify.com",
-      "shopifycloud",
-      "myshopify.com",
-    ],
+    bodyTokens: ["cdn.shopify.com", "shopifycloud", "myshopify.com"],
     headerNames: ["x-shopify-stage", "x-shopid", "x-shardid"],
     headerValues: [],
   },
   {
     id: "woocommerce",
-    bodyTokens: [
-      'content="woocommerce',
-      "/wp-content/plugins/woocommerce",
-      "wc-ajax",
-    ],
+    bodyTokens: ["/wp-content/plugins/woocommerce", "wc-ajax"],
     headerNames: ["x-wc-store-api-nonce"],
     headerValues: ["woocommerce"],
   },
   {
     id: "magento",
-    bodyTokens: [
-      'content="magento',
-      "/static/frontend/magento",
-      "mage-cache-storage",
-    ],
+    bodyTokens: ["/static/frontend/magento", "mage-cache-storage"],
     headerNames: ["x-magento-cache-debug", "x-magento-tags"],
     headerValues: [],
   },
   {
     id: "bigcommerce",
-    bodyTokens: ["cdn11.bigcommerce.com", 'content="bigcommerce'],
+    bodyTokens: ["cdn11.bigcommerce.com"],
     headerNames: ["x-bc-apigw-request-id"],
     headerValues: ["bigcommerce"],
   },
@@ -133,25 +129,36 @@ const META_REGEXES: ReadonlyArray<{ signal: string; re: RegExp }> = [
   },
 ];
 
+/**
+ * Platform meta regexes. We deliberately scope matches to two narrow shapes
+ * so unrelated descriptive copy doesn't trigger a false positive:
+ *   1. `<meta name="generator" content="...shopify...">` (the conventional
+ *      CMS/platform self-identification meta), or
+ *   2. `<meta name="shopify...">` / `<meta name="woocommerce...">` etc. —
+ *      a platform-named meta tag.
+ * A previous implementation matched any meta attribute value containing the
+ * vendor token, which over-matched pages like
+ * `<meta name="description" content="How to shopify your store">`.
+ */
 const PLATFORM_META_REGEXES: ReadonlyArray<{
   id: PlatformRule["id"];
   re: RegExp;
 }> = [
   {
     id: "shopify",
-    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*shopify[^"']*["'][^>]*>/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*shopify[^"']*["']|<meta\s+[^>]*name\s*=\s*["']shopify[^"']*["']/i,
   },
   {
     id: "woocommerce",
-    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*woocommerce[^"']*["'][^>]*>/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*woocommerce[^"']*["']|<meta\s+[^>]*name\s*=\s*["']woocommerce[^"']*["']/i,
   },
   {
     id: "magento",
-    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*magento[^"']*["'][^>]*>/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*magento[^"']*["']|<meta\s+[^>]*name\s*=\s*["']magento[^"']*["']/i,
   },
   {
     id: "bigcommerce",
-    re: /<meta\s+[^>]*(?:name|content)\s*=\s*["'][^"']*bigcommerce[^"']*["'][^>]*>/i,
+    re: /<meta\s+[^>]*name\s*=\s*["']generator["'][^>]*content\s*=\s*["'][^"']*bigcommerce[^"']*["']|<meta\s+[^>]*name\s*=\s*["']bigcommerce[^"']*["']/i,
   },
 ];
 
@@ -169,42 +176,52 @@ const URL_PROBES = [
 function detectPlatforms(
   body: string,
   headers: Record<string, string>,
-): Set<string> {
-  const found = new Set<string>();
+): string[] {
+  const found: string[] = [];
   const lower = body.toLowerCase();
   for (const rule of PLATFORM_RULES) {
     if (rule.bodyTokens.some((tok) => lower.includes(tok.toLowerCase()))) {
-      found.add(`platform:${rule.id}`);
+      found.push(`platform:${rule.id}`);
       continue;
     }
     if (rule.headerNames.some((h) => headers[h.toLowerCase()] !== undefined)) {
-      found.add(`platform:${rule.id}`);
+      found.push(`platform:${rule.id}`);
       continue;
     }
     if (rule.headerValues.length > 0) {
       const joined = Object.values(headers).join(" ").toLowerCase();
       if (rule.headerValues.some((v) => joined.includes(v.toLowerCase()))) {
-        found.add(`platform:${rule.id}`);
+        found.push(`platform:${rule.id}`);
       }
     }
   }
   return found;
 }
 
-function detectMeta(body: string): Set<string> {
-  const found = new Set<string>();
-  for (const { signal, re } of META_REGEXES) {
-    if (re.test(body)) found.add(signal);
-  }
+function detectMeta(body: string): string[] {
+  const found: string[] = [];
+  const seen = new Set<string>();
   for (const { id, re } of PLATFORM_META_REGEXES) {
-    if (re.test(body)) found.add(`meta:${id}`);
+    const signal = `meta:${id}`;
+    if (!seen.has(signal) && re.test(body)) {
+      seen.add(signal);
+      found.push(signal);
+    }
+  }
+  for (const { signal, re } of META_REGEXES) {
+    if (!seen.has(signal) && re.test(body)) {
+      seen.add(signal);
+      found.push(signal);
+    }
   }
   return found;
 }
 
-async function detectUrlSignals(ctx: ScanContext): Promise<Set<string>> {
-  // Use GET (not HEAD) because some origins reject HEAD; pass a short
-  // timeout to avoid blocking the scan if a 404 path hangs.
+async function detectUrlSignals(ctx: ScanContext): Promise<string[]> {
+  // Use HEAD to minimise response size; most origins honour HEAD on /checkout,
+  // /product, /shop, /cart. Order is preserved by returning probes in
+  // `URL_PROBES` declaration order — the final signal list deliberately keeps
+  // platform:* → meta:* → url:* detection order (see `detectCommerce`).
   const probes = URL_PROBES.map(async (path) => {
     try {
       const outcome = await ctx.fetch(path, { method: "HEAD" });
@@ -217,7 +234,7 @@ async function detectUrlSignals(ctx: ScanContext): Promise<Set<string>> {
     return undefined;
   });
   const resolved = await Promise.all(probes);
-  return new Set(resolved.filter((s): s is string => s !== undefined));
+  return resolved.filter((s): s is string => s !== undefined);
 }
 
 // ---------------------------------------------------------------------------
@@ -232,22 +249,35 @@ export async function detectCommerce(
     detectUrlSignals(ctx),
   ]);
 
-  const signals = new Set<string>();
+  // Preserve detection order: `platform:* → meta:* → url:*`. The shopify
+  // oracle (`research/raw/scan-shopify.json` commerceSignals) emits signals
+  // in this order, and downstream consumers may rely on it (scoring, UI
+  // grouping). Within each bucket, order is preserved per the detector's
+  // declaration order (PLATFORM_RULES / META_REGEXES / URL_PROBES).
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  const push = (s: string): void => {
+    if (!seen.has(s)) {
+      seen.add(s);
+      ordered.push(s);
+    }
+  };
 
   if (homepage.response !== undefined) {
     const body = homepage.body ?? "";
     const headers = homepage.response.headers;
-    for (const s of detectPlatforms(body, headers)) signals.add(s);
-    for (const s of detectMeta(body)) signals.add(s);
+    for (const s of detectPlatforms(body, headers)) push(s);
+    for (const s of detectMeta(body)) push(s);
   }
+  for (const s of urlSignals) push(s);
 
-  for (const s of urlSignals) signals.add(s);
-
-  // Sorted for stable output — consumers can rely on order without
-  // callers having to sort themselves.
-  const commerceSignals = [...signals].sort();
   return {
-    isCommerce: commerceSignals.length > 0,
-    commerceSignals,
+    isCommerce: ordered.length > 0,
+    commerceSignals: ordered,
   };
 }
+
+// TODO(phase-3): When the orchestrator wires checks together it will normalise
+// the signature shape for commerce checks by widening `ScanContext` to include
+// `isCommerce` / `commerceSignals` directly (M4-norm from iter-1 review), so
+// individual checks no longer need a bespoke `opts.isCommerce` parameter.

--- a/tests/engine/acp.spec.ts
+++ b/tests/engine/acp.spec.ts
@@ -112,7 +112,12 @@ describe("acp — shopify oracle (isCommerce=true)", () => {
   });
 });
 
-describe("acp — oracle round-trip (M1)", () => {
+// These tests assert that the check's gating behaviour (status + message)
+// is consistent across all oracle origins when the probe responses are
+// stubbed to the negative baseline. They do NOT replay the full evidence
+// timeline structurally — that is deferred pending real pass-case
+// fixtures, after which we'd switch to `expectCheckMatchesOracle`.
+describe("acp — gating across origins", () => {
   it.each(ALL_SITES)(
     "matches the oracle status + message for %s",
     async (site) => {

--- a/tests/engine/acp.spec.ts
+++ b/tests/engine/acp.spec.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { makeFetchStub } from "./_helpers/oracle";
+import { ALL_SITES, loadOracle, makeFetchStub } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
 import { checkAcp } from "@/lib/engine/checks/acp";
@@ -110,6 +110,27 @@ describe("acp — shopify oracle (isCommerce=true)", () => {
     const result = await checkAcp(ctx, { isCommerce: true });
     expect(result.status).toBe("fail");
   });
+});
+
+describe("acp — oracle round-trip (M1)", () => {
+  it.each(ALL_SITES)(
+    "matches the oracle status + message for %s",
+    async (site) => {
+      const fixture = loadOracle(site);
+      const oracle = fixture.raw.checks.commerce.acp;
+      const isCommerce = Boolean(fixture.raw.isCommerce);
+      const { fetchImpl } = makeFetchStub({
+        [`${fixture.origin}/.well-known/acp.json`]: {
+          status: 404,
+          headers: { "content-type": "text/plain;charset=UTF-8" },
+        },
+      });
+      const ctx = createScanContext({ url: fixture.origin, fetchImpl });
+      const result = await checkAcp(ctx, { isCommerce });
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+    },
+  );
 });
 
 describe("acp — non-commerce gating", () => {

--- a/tests/engine/acp.spec.ts
+++ b/tests/engine/acp.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Failing specs for the `acp` commerce check (Agentic Commerce Protocol).
+ *
+ * Reference: FINDINGS §3 + §9.
+ * Oracle: research/raw/scan-*.json → checks.commerce.acp
+ *
+ * Fetch plan: GET /.well-known/acp.json.
+ * Pass iff 200 + JSON body with:
+ *   - protocol.name === "acp"
+ *   - api_base_url present
+ *   - transports[] non-empty
+ *   - capabilities.services[] non-empty
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { makeFetchStub } from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+import { checkAcp } from "@/lib/engine/checks/acp";
+
+describe("acp — shopify oracle (isCommerce=true)", () => {
+  it("fails with a 2-step timeline on a 404", async () => {
+    const origin = "https://www.shopify.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/acp.json`]: {
+        status: 404,
+        headers: {
+          "content-type": "text/plain;charset=UTF-8",
+          "content-length": "9",
+        },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+
+    const result = await checkAcp(ctx, { isCommerce: true });
+
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("ACP discovery document not found");
+    expect(result.evidence.map((s) => s.action)).toEqual(["fetch", "conclude"]);
+  });
+
+  it("passes with a valid ACP discovery document", async () => {
+    const origin = "https://acp.test";
+    const body = JSON.stringify({
+      protocol: { name: "acp", version: "1.0" },
+      api_base_url: "https://acp.test/api",
+      transports: [{ kind: "https" }],
+      capabilities: { services: ["catalog"] },
+    });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/acp.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkAcp(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when protocol.name is wrong", async () => {
+    const origin = "https://wrong.test";
+    const body = JSON.stringify({
+      protocol: { name: "other" },
+      api_base_url: "x",
+      transports: [{}],
+      capabilities: { services: ["x"] },
+    });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/acp.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkAcp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when transports is empty", async () => {
+    const origin = "https://empty.test";
+    const body = JSON.stringify({
+      protocol: { name: "acp" },
+      api_base_url: "x",
+      transports: [],
+      capabilities: { services: ["x"] },
+    });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/acp.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkAcp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails on transport error", async () => {
+    const origin = "https://broken.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/acp.json`]: new Error("ECONNRESET"),
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkAcp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("acp — non-commerce gating", () => {
+  it("returns neutral with suffix on a non-commerce site", async () => {
+    const origin = "https://vercel.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/acp.json`]: {
+        status: 404,
+        headers: { "content-type": "text/plain;charset=UTF-8" },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkAcp(ctx, { isCommerce: false });
+    expect(result.status).toBe("neutral");
+    expect(result.message).toBe(
+      "ACP discovery document not found (not a commerce site)",
+    );
+  });
+});

--- a/tests/engine/ap2.spec.ts
+++ b/tests/engine/ap2.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Failing specs for the `ap2` commerce check.
+ *
+ * Reference: FINDINGS §3 + §9 + §13 (Gap #5).
+ * Oracle: research/raw/scan-*.json → checks.commerce.ap2
+ *
+ * AP2 has no direct probe. Its verdict is derived from the a2aAgentCard
+ * result produced by impl-C. To avoid a cyclic dependency (and to allow
+ * Phase 2 fan-out before impl-C merges), `checkAp2` accepts the a2a card's
+ * CheckResult as a nullable parameter. When `null` (card not yet computed
+ * or opt-out), the check reports the same "no A2A Agent Card" conclusion
+ * as a failing a2a result — this mirrors the shopify / vercel oracles,
+ * which both record a missing card.
+ *
+ * isCommerce gating: same as the other commerce checks — when
+ * `isCommerce === false`, status is forced to "neutral" and
+ * " (not a commerce site)" is appended to the message. The conclusion
+ * finding summary is preserved verbatim.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { CheckResultSchema, type CheckResult } from "@/lib/schema";
+import { checkAp2 } from "@/lib/engine/checks/ap2";
+
+// ---------------------------------------------------------------------------
+// A2A card fixtures — mimic the CheckResult the a2a-agent-card check would
+// produce. We deliberately do NOT import the real check here; impl-E must
+// not depend on impl-C.
+// ---------------------------------------------------------------------------
+
+function a2aFail(): CheckResult {
+  return {
+    status: "fail",
+    message: "A2A Agent Card not found",
+    evidence: [
+      {
+        action: "conclude",
+        label: "Conclusion",
+        finding: { outcome: "negative", summary: "A2A Agent Card not found" },
+      },
+    ],
+    durationMs: 1,
+  };
+}
+
+function a2aPassWithSkill(skills: string[]): CheckResult {
+  return {
+    status: "pass",
+    message: "A2A Agent Card found",
+    details: {
+      name: "Shop",
+      version: "1.0",
+      skills: skills.map((id) => ({ id })),
+    },
+    evidence: [
+      {
+        action: "conclude",
+        label: "Conclusion",
+        finding: { outcome: "positive", summary: "A2A Agent Card found" },
+      },
+    ],
+    durationMs: 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shopify / commerce oracle round-trip
+// ---------------------------------------------------------------------------
+
+describe("ap2 — shopify oracle (isCommerce=true)", () => {
+  it("fails with a single conclude step when no A2A card is available", async () => {
+    const result = await checkAp2({
+      isCommerce: true,
+      a2aAgentCard: a2aFail(),
+    });
+
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("AP2 not detected (no A2A Agent Card)");
+    expect(result.evidence).toHaveLength(1);
+    expect(result.evidence[0]!.action).toBe("conclude");
+    expect(result.evidence[0]!.finding).toEqual({
+      outcome: "negative",
+      summary: "No A2A Agent Card found -- AP2 requires an A2A Agent Card",
+    });
+  });
+
+  it("fails with the same conclusion when the a2a result is null (not yet computed)", async () => {
+    const result = await checkAp2({ isCommerce: true, a2aAgentCard: null });
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("AP2 not detected (no A2A Agent Card)");
+  });
+
+  it("passes when the A2A card advertises an AP2-compatible commerce skill", async () => {
+    const result = await checkAp2({
+      isCommerce: true,
+      a2aAgentCard: a2aPassWithSkill(["ap2.payments", "catalog"]),
+    });
+    expect(result.status).toBe("pass");
+    expect(result.message).toMatch(/AP2/i);
+  });
+
+  it("fails when the A2A card passes but declares no commerce-related skill", async () => {
+    const result = await checkAp2({
+      isCommerce: true,
+      a2aAgentCard: a2aPassWithSkill(["weather", "support"]),
+    });
+    expect(result.status).toBe("fail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-commerce gating
+// ---------------------------------------------------------------------------
+
+describe("ap2 — non-commerce gating", () => {
+  it("returns neutral with suffix when the site is not commerce", async () => {
+    const result = await checkAp2({ isCommerce: false, a2aAgentCard: null });
+    expect(result.status).toBe("neutral");
+    expect(result.message).toBe(
+      "AP2 not detected (no A2A Agent Card) (not a commerce site)",
+    );
+    // Inner conclusion summary stays the same.
+    expect(result.evidence[0]!.finding.summary).toBe(
+      "No A2A Agent Card found -- AP2 requires an A2A Agent Card",
+    );
+  });
+
+  it("keeps the pass-path conclusion when a2a passes but site is not commerce", async () => {
+    const result = await checkAp2({
+      isCommerce: false,
+      a2aAgentCard: a2aPassWithSkill(["ap2.payments"]),
+    });
+    expect(result.status).toBe("neutral");
+    // Message suffix appended, but the underlying derivation is preserved.
+    expect(result.message).toMatch(/not a commerce site/);
+  });
+});

--- a/tests/engine/ap2.spec.ts
+++ b/tests/engine/ap2.spec.ts
@@ -117,7 +117,12 @@ describe("ap2 — shopify oracle (isCommerce=true)", () => {
 // Non-commerce gating
 // ---------------------------------------------------------------------------
 
-describe("ap2 — oracle round-trip (M1)", () => {
+// These tests assert that the check's gating behaviour (status + message)
+// is consistent across all oracle origins when the probe responses are
+// stubbed to the negative baseline. They do NOT replay the full evidence
+// timeline structurally — that is deferred pending real pass-case
+// fixtures, after which we'd switch to `expectCheckMatchesOracle`.
+describe("ap2 — gating across origins", () => {
   it.each(ALL_SITES)(
     "matches the oracle status + message for %s",
     async (site) => {

--- a/tests/engine/ap2.spec.ts
+++ b/tests/engine/ap2.spec.ts
@@ -22,6 +22,7 @@ import { describe, it, expect } from "vitest";
 
 import { CheckResultSchema, type CheckResult } from "@/lib/schema";
 import { checkAp2 } from "@/lib/engine/checks/ap2";
+import { ALL_SITES, loadOracle } from "./_helpers/oracle";
 
 // ---------------------------------------------------------------------------
 // A2A card fixtures — mimic the CheckResult the a2a-agent-card check would
@@ -79,8 +80,10 @@ describe("ap2 — shopify oracle (isCommerce=true)", () => {
     expect(result.status).toBe("fail");
     expect(result.message).toBe("AP2 not detected (no A2A Agent Card)");
     expect(result.evidence).toHaveLength(1);
-    expect(result.evidence[0]!.action).toBe("conclude");
-    expect(result.evidence[0]!.finding).toEqual({
+    const step = result.evidence[0];
+    expect(step).toBeDefined();
+    expect(step?.action).toBe("conclude");
+    expect(step?.finding).toEqual({
       outcome: "negative",
       summary: "No A2A Agent Card found -- AP2 requires an A2A Agent Card",
     });
@@ -114,6 +117,21 @@ describe("ap2 — shopify oracle (isCommerce=true)", () => {
 // Non-commerce gating
 // ---------------------------------------------------------------------------
 
+describe("ap2 — oracle round-trip (M1)", () => {
+  it.each(ALL_SITES)(
+    "matches the oracle status + message for %s",
+    async (site) => {
+      const fixture = loadOracle(site);
+      const oracle = fixture.raw.checks.commerce.ap2;
+      const isCommerce = Boolean(fixture.raw.isCommerce);
+      // All 5 oracles record a missing A2A card, so we pass `null`.
+      const result = await checkAp2({ isCommerce, a2aAgentCard: null });
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+    },
+  );
+});
+
 describe("ap2 — non-commerce gating", () => {
   it("returns neutral with suffix when the site is not commerce", async () => {
     const result = await checkAp2({ isCommerce: false, a2aAgentCard: null });
@@ -122,7 +140,9 @@ describe("ap2 — non-commerce gating", () => {
       "AP2 not detected (no A2A Agent Card) (not a commerce site)",
     );
     // Inner conclusion summary stays the same.
-    expect(result.evidence[0]!.finding.summary).toBe(
+    const step = result.evidence[0];
+    expect(step).toBeDefined();
+    expect(step?.finding.summary).toBe(
       "No A2A Agent Card found -- AP2 requires an A2A Agent Card",
     );
   });

--- a/tests/engine/commerce-signals.spec.ts
+++ b/tests/engine/commerce-signals.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Failing specs for the `detectCommerce` helper.
+ *
+ * Oracle: `research/raw/scan-*.json` → top-level `isCommerce` + `commerceSignals`.
+ * Reference: `research/FINDINGS.md` §3 + §9 ("Commerce site detection").
+ *
+ * Signals detected from the homepage HTML + path probes:
+ *   - platform:shopify|woocommerce|magento|bigcommerce  (HTML / headers)
+ *   - meta:<token>                                      (<meta name|property>)
+ *   - url:/checkout|/product|/shop|/cart                (HEAD returns 200)
+ *
+ * The 5 real fixtures provide the oracle: only `shopify` is `isCommerce=true`.
+ * For cf-dev, cf, example, vercel the helper must return `isCommerce=false`
+ * with `commerceSignals=[]` (we intentionally model conservatively; the
+ * vercel oracle's `schema:Offer` and `url:/product` signals come from rules
+ * we do not implement in this phase — the top-level `isCommerce` stays
+ * `false` either way, so scoring round-trips correctly).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { makeFetchStub } from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { detectCommerce } from "@/lib/engine/commerce-signals";
+
+// ---------------------------------------------------------------------------
+// Synthetic fixtures (oracle only records the final signal set, not homepage
+// HTML — we model a realistic Shopify homepage + path HEAD probes that would
+// produce the observed signal set).
+// ---------------------------------------------------------------------------
+
+const SHOPIFY_HTML = [
+  '<!doctype html><html lang="en"><head>',
+  '<meta charset="utf-8">',
+  '<meta name="generator" content="Shopify">',
+  '<title>Shopify</title>',
+  // A representative inline script reference to the Shopify platform CDN.
+  '<script src="https://cdn.shopify.com/shopifycloud/shopify/assets/static/controllers/checkout-web-pixel-shared-worker.js"></script>',
+  "</head><body>Shopify</body></html>",
+].join("\n");
+
+const PLAIN_HTML =
+  '<!doctype html><html><head><title>Hello</title></head><body>hi</body></html>';
+
+// ---------------------------------------------------------------------------
+// Shopify (isCommerce=true) oracle round-trip
+// ---------------------------------------------------------------------------
+
+describe("detectCommerce — shopify fixture", () => {
+  it("detects the oracle signal set for the shopify origin", async () => {
+    const origin = "https://www.shopify.com";
+    const { fetchImpl } = makeFetchStub({
+      // Homepage GET memoised by ctx.getHomepage()
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: SHOPIFY_HTML,
+      },
+      // HEAD probes for url:* signals. Shopify oracle reports
+      // ["url:/checkout", "url:/product", "url:/shop"] but NOT "url:/cart".
+      [`${origin}/checkout`]: { status: 200, headers: {}, body: "" },
+      [`${origin}/product`]: { status: 200, headers: {}, body: "" },
+      [`${origin}/shop`]: { status: 200, headers: {}, body: "" },
+      [`${origin}/cart`]: { status: 404, headers: {}, body: "" },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+
+    const result = await detectCommerce(ctx);
+
+    expect(result.isCommerce).toBe(true);
+    // Must contain the oracle signals (order-insensitive).
+    expect(result.commerceSignals).toEqual(
+      expect.arrayContaining([
+        "platform:shopify",
+        "meta:shopify",
+        "url:/checkout",
+        "url:/product",
+        "url:/shop",
+      ]),
+    );
+    expect(result.commerceSignals).not.toContain("url:/cart");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-commerce fixtures
+// ---------------------------------------------------------------------------
+
+describe("detectCommerce — non-commerce fixtures", () => {
+  it.each(["https://example.com", "https://www.cloudflare.com", "https://developers.cloudflare.com"])(
+    "returns isCommerce=false with no signals for %s",
+    async (origin) => {
+      const { fetchImpl } = makeFetchStub({
+        [`${origin}/`]: {
+          status: 200,
+          headers: { "content-type": "text/html" },
+          body: PLAIN_HTML,
+        },
+        [`${origin}/checkout`]: { status: 404 },
+        [`${origin}/product`]: { status: 404 },
+        [`${origin}/shop`]: { status: 404 },
+        [`${origin}/cart`]: { status: 404 },
+      });
+      const ctx = createScanContext({ url: origin, fetchImpl });
+      const result = await detectCommerce(ctx);
+      expect(result.isCommerce).toBe(false);
+      expect(result.commerceSignals).toEqual([]);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Platform variants (regression guard)
+// ---------------------------------------------------------------------------
+
+describe("detectCommerce — platform heuristics", () => {
+  it("flags a WooCommerce generator meta", async () => {
+    const origin = "https://woo.test";
+    const html =
+      '<html><head><meta name="generator" content="WooCommerce 7.1.0"></head></html>';
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toContain("platform:woocommerce");
+  });
+
+  it("flags a Magento platform header", async () => {
+    const origin = "https://mage.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: {
+          "content-type": "text/html",
+          "x-magento-cache-debug": "HIT",
+        },
+        body: "<html></html>",
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toContain("platform:magento");
+  });
+
+  it("flags a BigCommerce inline script URL", async () => {
+    const origin = "https://bc.test";
+    const html =
+      '<html><head><script src="https://cdn11.bigcommerce.com/s-xyz/app.js"></script></head></html>';
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toContain("platform:bigcommerce");
+  });
+
+  it("flags an og:type=product meta", async () => {
+    const origin = "https://og.test";
+    const html =
+      '<html><head><meta property="og:type" content="product"></head></html>';
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toContain("meta:product");
+  });
+
+  it("flags a <meta name=\"product\"> meta", async () => {
+    const origin = "https://metaname.test";
+    const html =
+      '<html><head><meta name="product" content="Widget"></head></html>';
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toContain("meta:product");
+  });
+
+  it("flags every url:* signal when each path returns 200", async () => {
+    const origin = "https://cart.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: PLAIN_HTML,
+      },
+      [`${origin}/checkout`]: { status: 200 },
+      [`${origin}/product`]: { status: 200 },
+      [`${origin}/shop`]: { status: 200 },
+      [`${origin}/cart`]: { status: 200 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toEqual(
+      expect.arrayContaining([
+        "url:/checkout",
+        "url:/product",
+        "url:/shop",
+        "url:/cart",
+      ]),
+    );
+  });
+
+  it("returns no signals when the homepage fetch errors", async () => {
+    const origin = "https://broken.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: new Error("ECONNRESET"),
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(false);
+    expect(result.commerceSignals).toEqual([]);
+  });
+
+  it("tolerates individual HEAD probe failures", async () => {
+    const origin = "https://parthead.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: PLAIN_HTML,
+      },
+      [`${origin}/checkout`]: new Error("ETIMEDOUT"),
+      [`${origin}/product`]: { status: 200 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toEqual(["url:/product"]);
+  });
+});

--- a/tests/engine/commerce-signals.spec.ts
+++ b/tests/engine/commerce-signals.spec.ts
@@ -21,7 +21,8 @@ import { describe, it, expect } from "vitest";
 
 import { makeFetchStub } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
-import { detectCommerce } from "@/lib/engine/commerce-signals";
+import { applyCommerceGate, detectCommerce } from "@/lib/engine/commerce-signals";
+import type { CheckResult } from "@/lib/schema";
 
 // ---------------------------------------------------------------------------
 // Synthetic fixtures (oracle only records the final signal set, not homepage
@@ -114,10 +115,31 @@ describe("detectCommerce — non-commerce fixtures", () => {
 // ---------------------------------------------------------------------------
 
 describe("detectCommerce — platform heuristics", () => {
-  it("flags a WooCommerce generator meta", async () => {
+  it("flags a WooCommerce generator meta as meta:woocommerce", async () => {
     const origin = "https://woo.test";
     const html =
       '<html><head><meta name="generator" content="WooCommerce 7.1.0"></head></html>';
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toContain("meta:woocommerce");
+  });
+
+  it("flags a WooCommerce plugin path as platform:woocommerce", async () => {
+    const origin = "https://woo2.test";
+    const html =
+      '<html><head><link rel="stylesheet" href="/wp-content/plugins/woocommerce/assets/css/woocommerce.css"></head></html>';
     const { fetchImpl } = makeFetchStub({
       [`${origin}/`]: {
         status: 200,
@@ -261,6 +283,64 @@ describe("detectCommerce — platform heuristics", () => {
     expect(result.commerceSignals).toEqual([]);
   });
 
+  it("does NOT treat descriptive meta copy as a platform signal (H2 regression)", async () => {
+    const origin = "https://desc.test";
+    // A marketing-style description meta that mentions "shopify" in prose
+    // must not be counted as a Shopify platform signal.
+    const html =
+      '<!doctype html><html><head>' +
+      '<meta name="description" content="How to shopify your store">' +
+      '</head><body>hi</body></html>';
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(false);
+    expect(result.commerceSignals).toEqual([]);
+  });
+
+  it("emits signals in platform -> meta -> url detection order (M2)", async () => {
+    // Mirrors the shopify oracle's `commerceSignals` array ordering:
+    // ["platform:shopify", "meta:shopify", "url:/checkout",
+    //  "url:/product", "url:/shop"].
+    const origin = "https://www.shopify.com";
+    const html = [
+      "<!doctype html><html><head>",
+      '<meta name="generator" content="Shopify">',
+      '<script src="https://cdn.shopify.com/app.js"></script>',
+      "</head><body>shop</body></html>",
+    ].join("\n");
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 200 },
+      [`${origin}/product`]: { status: 200 },
+      [`${origin}/shop`]: { status: 200 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.commerceSignals).toEqual([
+      "platform:shopify",
+      "meta:shopify",
+      "url:/checkout",
+      "url:/product",
+      "url:/shop",
+    ]);
+  });
+
   it("tolerates individual HEAD probe failures", async () => {
     const origin = "https://parthead.test";
     const { fetchImpl } = makeFetchStub({
@@ -278,5 +358,44 @@ describe("detectCommerce — platform heuristics", () => {
     const result = await detectCommerce(ctx);
     expect(result.isCommerce).toBe(true);
     expect(result.commerceSignals).toEqual(["url:/product"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyCommerceGate — message suffix / trailing-period handling (L2)
+// ---------------------------------------------------------------------------
+
+describe("applyCommerceGate", () => {
+  it("passes the result through unchanged when isCommerce is true", () => {
+    const input: CheckResult = {
+      status: "fail",
+      message: "X not detected",
+      evidence: [],
+      durationMs: 0,
+    };
+    expect(applyCommerceGate(input, true)).toBe(input);
+  });
+
+  it("strips a trailing period before appending the non-commerce suffix", () => {
+    const input: CheckResult = {
+      status: "fail",
+      message: "X not detected.",
+      evidence: [],
+      durationMs: 0,
+    };
+    const out = applyCommerceGate(input, false);
+    expect(out.status).toBe("neutral");
+    expect(out.message).toBe("X not detected (not a commerce site)");
+  });
+
+  it("appends the suffix to a message without a trailing period", () => {
+    const input: CheckResult = {
+      status: "fail",
+      message: "X not detected",
+      evidence: [],
+      durationMs: 0,
+    };
+    const out = applyCommerceGate(input, false);
+    expect(out.message).toBe("X not detected (not a commerce site)");
   });
 });

--- a/tests/engine/commerce-signals.spec.ts
+++ b/tests/engine/commerce-signals.spec.ts
@@ -341,6 +341,60 @@ describe("detectCommerce — platform heuristics", () => {
     ]);
   });
 
+  it("matches the shopify fixture's commerceSignals array exactly (L5 fixture parity)", async () => {
+    // Directly reads the oracle's `commerceSignals` from
+    // `research/raw/scan-shopify.json` and asserts byte-for-byte parity
+    // with the detector's output under a realistic stub. This is stricter
+    // than the synthetic ordering test above because the oracle itself is
+    // the source of truth.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const oracle = require("../../research/raw/scan-shopify.json");
+    const origin = new URL(oracle.url).origin;
+    const html = [
+      "<!doctype html><html><head>",
+      '<meta name="generator" content="Shopify">',
+      '<script src="https://cdn.shopify.com/shopifycloud/shopify/assets/static/controllers/checkout-web-pixel-shared-worker.js"></script>',
+      "</head><body>shop</body></html>",
+    ].join("\n");
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 200 },
+      [`${origin}/product`]: { status: 200 },
+      [`${origin}/shop`]: { status: 200 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.commerceSignals).toEqual(oracle.commerceSignals);
+  });
+
+  it("flags a reversed-attribute Shopify generator meta (L2)", async () => {
+    const origin = "https://rev.test";
+    const html =
+      '<!doctype html><html><head>' +
+      '<meta content="Shopify" name="generator">' +
+      '</head><body>hi</body></html>';
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: html,
+      },
+      [`${origin}/checkout`]: { status: 404 },
+      [`${origin}/product`]: { status: 404 },
+      [`${origin}/shop`]: { status: 404 },
+      [`${origin}/cart`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await detectCommerce(ctx);
+    expect(result.isCommerce).toBe(true);
+    expect(result.commerceSignals).toContain("meta:shopify");
+  });
+
   it("tolerates individual HEAD probe failures", async () => {
     const origin = "https://parthead.test";
     const { fetchImpl } = makeFetchStub({

--- a/tests/engine/mpp.spec.ts
+++ b/tests/engine/mpp.spec.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { makeFetchStub } from "./_helpers/oracle";
+import { ALL_SITES, loadOracle, makeFetchStub } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
 import { checkMpp } from "@/lib/engine/checks/mpp";
@@ -165,6 +165,27 @@ describe("mpp — additional coverage", () => {
     const result = await checkMpp(ctx, { isCommerce: true });
     expect(result.status).toBe("fail");
   });
+});
+
+describe("mpp — oracle round-trip (M1)", () => {
+  it.each(ALL_SITES)(
+    "matches the oracle status + message for %s",
+    async (site) => {
+      const fixture = loadOracle(site);
+      const oracle = fixture.raw.checks.commerce.mpp;
+      const isCommerce = Boolean(fixture.raw.isCommerce);
+      const { fetchImpl } = makeFetchStub({
+        [`${fixture.origin}/openapi.json`]: {
+          status: 404,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        },
+      });
+      const ctx = createScanContext({ url: fixture.origin, fetchImpl });
+      const result = await checkMpp(ctx, { isCommerce });
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+    },
+  );
 });
 
 describe("mpp — non-commerce gating", () => {

--- a/tests/engine/mpp.spec.ts
+++ b/tests/engine/mpp.spec.ts
@@ -81,6 +81,92 @@ describe("mpp — shopify oracle (isCommerce=true)", () => {
   });
 });
 
+describe("mpp — additional coverage", () => {
+  it("passes when x-payment-info is nested inside an array", async () => {
+    const origin = "https://arr.test";
+    const body = JSON.stringify({
+      openapi: "3.0.0",
+      servers: [{ url: "https://arr.test", "x-payment-info": {} }],
+    });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes when x-payment-info is nested inside an operation", async () => {
+    const origin = "https://nested.test";
+    const body = JSON.stringify({
+      openapi: "3.0.0",
+      paths: {
+        "/pay": {
+          post: {
+            "x-payment-info": { amount: 100 },
+          },
+        },
+      },
+    });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails on a valid OpenAPI doc that has no x-payment-info", async () => {
+    const origin = "https://plain.test";
+    const body = JSON.stringify({ openapi: "3.0.0", paths: {} });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails when openapi.json returns 200 with a non-JSON body", async () => {
+    const origin = "https://nonjson.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails on a 500 response", async () => {
+    const origin = "https://svr.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 500,
+        headers: { "content-type": "text/plain" },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+});
+
 describe("mpp — non-commerce gating", () => {
   it("returns neutral with suffix on a non-commerce site", async () => {
     const origin = "https://vercel.com";

--- a/tests/engine/mpp.spec.ts
+++ b/tests/engine/mpp.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Failing specs for the `mpp` commerce check (Machine Payment Protocol).
+ *
+ * Reference: FINDINGS §3 + §9.
+ * Oracle: research/raw/scan-{shopify,vercel,...}.json → checks.commerce.mpp
+ *
+ * Fetch plan: GET /openapi.json. Pass iff 200 + JSON body containing an
+ * `x-payment-info` key (anywhere — OpenAPI root extensions or inside
+ * path-level operations).
+ *
+ * Non-JSON responses (HTML soft-404, 404) → fail.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { makeFetchStub } from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+import { checkMpp } from "@/lib/engine/checks/mpp";
+
+describe("mpp — shopify oracle (isCommerce=true)", () => {
+  it("fails with a 2-step timeline on a 404", async () => {
+    const origin = "https://www.shopify.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 404,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+
+    const result = await checkMpp(ctx, { isCommerce: true });
+
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("MPP payment discovery not detected");
+    expect(result.evidence.map((s) => s.action)).toEqual(["fetch", "conclude"]);
+  });
+
+  it("passes when openapi.json declares x-payment-info", async () => {
+    const origin = "https://mpp.test";
+    const body = JSON.stringify({
+      openapi: "3.0.0",
+      "x-payment-info": { currency: "USD" },
+      paths: {},
+    });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when openapi.json returns HTML (soft-404)", async () => {
+    const origin = "https://soft.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: "<html></html>",
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails on transport error", async () => {
+    const origin = "https://broken.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: new Error("ECONNRESET"),
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("mpp — non-commerce gating", () => {
+  it("returns neutral with suffix on a non-commerce site", async () => {
+    const origin = "https://vercel.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/openapi.json`]: {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: "<html></html>",
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkMpp(ctx, { isCommerce: false });
+    expect(result.status).toBe("neutral");
+    expect(result.message).toBe(
+      "MPP payment discovery not detected (not a commerce site)",
+    );
+  });
+});

--- a/tests/engine/mpp.spec.ts
+++ b/tests/engine/mpp.spec.ts
@@ -167,7 +167,12 @@ describe("mpp — additional coverage", () => {
   });
 });
 
-describe("mpp — oracle round-trip (M1)", () => {
+// These tests assert that the check's gating behaviour (status + message)
+// is consistent across all oracle origins when the probe responses are
+// stubbed to the negative baseline. They do NOT replay the full evidence
+// timeline structurally — that is deferred pending real pass-case
+// fixtures, after which we'd switch to `expectCheckMatchesOracle`.
+describe("mpp — gating across origins", () => {
   it.each(ALL_SITES)(
     "matches the oracle status + message for %s",
     async (site) => {

--- a/tests/engine/ucp.spec.ts
+++ b/tests/engine/ucp.spec.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { makeFetchStub } from "./_helpers/oracle";
+import { ALL_SITES, loadOracle, makeFetchStub } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
 import { checkUcp } from "@/lib/engine/checks/ucp";
@@ -82,6 +82,27 @@ describe("ucp — shopify oracle (isCommerce=true)", () => {
     const result = await checkUcp(ctx, { isCommerce: true });
     expect(result.status).toBe("fail");
   });
+});
+
+describe("ucp — oracle round-trip (M1)", () => {
+  it.each(ALL_SITES)(
+    "matches the oracle status + message for %s",
+    async (site) => {
+      const fixture = loadOracle(site);
+      const oracle = fixture.raw.checks.commerce.ucp;
+      const isCommerce = Boolean(fixture.raw.isCommerce);
+      const { fetchImpl } = makeFetchStub({
+        [`${fixture.origin}/.well-known/ucp`]: {
+          status: 404,
+          headers: { "content-type": "text/plain;charset=UTF-8" },
+        },
+      });
+      const ctx = createScanContext({ url: fixture.origin, fetchImpl });
+      const result = await checkUcp(ctx, { isCommerce });
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+    },
+  );
 });
 
 describe("ucp — non-commerce gating", () => {

--- a/tests/engine/ucp.spec.ts
+++ b/tests/engine/ucp.spec.ts
@@ -84,7 +84,12 @@ describe("ucp — shopify oracle (isCommerce=true)", () => {
   });
 });
 
-describe("ucp — oracle round-trip (M1)", () => {
+// These tests assert that the check's gating behaviour (status + message)
+// is consistent across all oracle origins when the probe responses are
+// stubbed to the negative baseline. They do NOT replay the full evidence
+// timeline structurally — that is deferred pending real pass-case
+// fixtures, after which we'd switch to `expectCheckMatchesOracle`.
+describe("ucp — gating across origins", () => {
   it.each(ALL_SITES)(
     "matches the oracle status + message for %s",
     async (site) => {

--- a/tests/engine/ucp.spec.ts
+++ b/tests/engine/ucp.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Failing specs for the `ucp` commerce check (Universal Commerce Protocol).
+ *
+ * Reference: FINDINGS §3 + §9.
+ * Oracle: research/raw/scan-*.json → checks.commerce.ucp
+ *
+ * Fetch plan: GET /.well-known/ucp.
+ * Pass iff 200 + JSON with `protocol_version`, `services`, `capabilities`,
+ * and `endpoints` fields. Otherwise fail.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { makeFetchStub } from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+import { checkUcp } from "@/lib/engine/checks/ucp";
+
+describe("ucp — shopify oracle (isCommerce=true)", () => {
+  it("fails with a 2-step timeline on a 404", async () => {
+    const origin = "https://www.shopify.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/ucp`]: {
+        status: 404,
+        headers: {
+          "content-type": "text/plain;charset=UTF-8",
+          "content-length": "9",
+        },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+
+    const result = await checkUcp(ctx, { isCommerce: true });
+
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("UCP profile not found");
+    expect(result.evidence.map((s) => s.action)).toEqual(["fetch", "conclude"]);
+  });
+
+  it("passes with a valid UCP profile", async () => {
+    const origin = "https://ucp.test";
+    const body = JSON.stringify({
+      protocol_version: "1.0",
+      services: ["checkout"],
+      capabilities: ["payments"],
+      endpoints: { checkout: "/api/checkout" },
+    });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/ucp`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkUcp(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when the UCP JSON is missing required fields", async () => {
+    const origin = "https://partial.test";
+    const body = JSON.stringify({ protocol_version: "1.0" });
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/ucp`]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkUcp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails on transport error", async () => {
+    const origin = "https://broken.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/ucp`]: new Error("ECONNRESET"),
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkUcp(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("ucp — non-commerce gating", () => {
+  it("returns neutral with suffix on a non-commerce site", async () => {
+    const origin = "https://vercel.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/.well-known/ucp`]: {
+        status: 404,
+        headers: { "content-type": "text/plain;charset=UTF-8" },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkUcp(ctx, { isCommerce: false });
+    expect(result.status).toBe("neutral");
+    expect(result.message).toBe("UCP profile not found (not a commerce site)");
+  });
+});

--- a/tests/engine/x402.spec.ts
+++ b/tests/engine/x402.spec.ts
@@ -268,6 +268,61 @@ describe("x402 — additional coverage", () => {
     expect(result.status).toBe("fail");
   });
 
+  it("hostMatches returns false for malformed scheme URLs (defensive URL parsing)", async () => {
+    // A bazaar entry carrying a malformed scheme-ish candidate (e.g.
+    // `ht!tp://nonsense`) would cause `new URL(...)` to throw. The
+    // `hostMatches` helper is exercised indirectly via the bazaar match
+    // path — we verify that a single bad entry does not abort iteration
+    // and that a subsequent valid exact-match entry still passes.
+    const origin = "https://resilient.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          data: [
+            { origin: "ht!tp://nonsense" },
+            { url: "://missing-scheme" },
+            { host: "resilient.test" },
+          ],
+        }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    // If the malformed URL threw unhandled, the outer bazaarMatchesHost
+    // try/catch would swallow it and drop the valid entry → fail. A pass
+    // here proves hostMatches skipped the bad candidate and continued.
+    expect(result.status).toBe("pass");
+  });
+
+  it("returns fail (not error) when every bazaar candidate is a malformed URL", async () => {
+    // Exercises the defensive branch in isolation: no valid candidate
+    // follows the malformed ones, so the scan must return a clean fail.
+    const origin = "https://allbad.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          data: [
+            { origin: "ht!tp://nonsense" },
+            { url: "http://[not-a-valid-ipv6" },
+          ],
+        }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
   it("matches an exact-hostname bare-host bazaar entry (H1 positive case)", async () => {
     const origin = "https://exact.test";
     const { fetchImpl } = makeFetchStub({

--- a/tests/engine/x402.spec.ts
+++ b/tests/engine/x402.spec.ts
@@ -21,7 +21,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { makeFetchStub } from "./_helpers/oracle";
+import { ALL_SITES, loadOracle, makeFetchStub } from "./_helpers/oracle";
 import { createScanContext } from "@/lib/engine/context";
 import { CheckResultSchema } from "@/lib/schema";
 import { checkX402 } from "@/lib/engine/checks/x402";
@@ -168,8 +168,9 @@ describe("x402 — additional coverage", () => {
     const ctx = createScanContext({ url: origin, fetchImpl });
     const result = await checkX402(ctx, { isCommerce: true });
     expect(result.status).toBe("fail");
-    const bazaarStep = result.evidence[1]!;
-    expect(bazaarStep.finding.summary).toMatch(/Bazaar API request failed/);
+    const bazaarStep = result.evidence[1];
+    expect(bazaarStep).toBeDefined();
+    expect(bazaarStep?.finding.summary).toMatch(/Bazaar API request failed/);
   });
 
   it("records a non-200 bazaar summary when the bazaar returns 500", async () => {
@@ -183,8 +184,9 @@ describe("x402 — additional coverage", () => {
     const ctx = createScanContext({ url: origin, fetchImpl });
     const result = await checkX402(ctx, { isCommerce: true });
     expect(result.status).toBe("fail");
-    const bazaarStep = result.evidence[1]!;
-    expect(bazaarStep.finding.summary).toBe("Bazaar API returned 500");
+    const bazaarStep = result.evidence[1];
+    expect(bazaarStep).toBeDefined();
+    expect(bazaarStep?.finding.summary).toBe("Bazaar API returned 500");
   });
 
   it("tolerates a bazaar body that is not valid JSON", async () => {
@@ -240,6 +242,100 @@ describe("x402 — additional coverage", () => {
     expect(result.status).toBe("pass");
   });
 
+  it("does NOT match a bazaar entry whose host is a suffix-confusion of the scan host (H1)", async () => {
+    // Scanning `a.com`; bazaar entry points to `a.com.evil.test`. Under the
+    // old `.includes()` comparison this would match — the fix requires exact
+    // hostname equality.
+    const origin = "https://a.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          data: [
+            { origin: "https://a.com.evil.test/", resource: "/api" },
+            { host: "a.com.evil.test" },
+            { url: "https://evil.test/path?target=a.com" },
+          ],
+        }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("matches an exact-hostname bare-host bazaar entry (H1 positive case)", async () => {
+    const origin = "https://exact.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data: [{ host: "exact.test" }] }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("does NOT pass on a 402 with an arbitrary (non-x402) body (L5)", async () => {
+    // A Stripe-style error envelope returned with HTTP 402 must not count as
+    // an x402 payment requirements document.
+    const origin = "https://stripe402.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: {
+        status: 402,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          error: { type: "card_error", message: "Your card was declined." },
+        }),
+      },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+    const apiStep = result.evidence[2];
+    expect(apiStep).toBeDefined();
+    expect(apiStep?.finding.summary).toMatch(
+      /402 but body is not an x402 payment requirements document/,
+    );
+  });
+
+  it("passes when the 402 body has only an accepts[] array (L5 accepts-only)", async () => {
+    const origin = "https://accepts.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: {
+        status: 402,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ accepts: [{ scheme: "exact", network: "base" }] }),
+      },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
   it("records a transport-error finding when a homepage probe errors", async () => {
     const origin = "https://home-err.test";
     const { fetchImpl } = makeFetchStub({
@@ -255,8 +351,39 @@ describe("x402 — additional coverage", () => {
     const ctx = createScanContext({ url: origin, fetchImpl });
     const result = await checkX402(ctx, { isCommerce: true });
     expect(result.status).toBe("fail");
-    expect(result.evidence[0]!.finding.summary).toMatch(/request failed/);
+    const homeStep = result.evidence[0];
+    expect(homeStep).toBeDefined();
+    expect(homeStep?.finding.summary).toMatch(/request failed/);
   });
+});
+
+describe("x402 — oracle round-trip (M1)", () => {
+  it.each(ALL_SITES)(
+    "matches the oracle status + message for %s",
+    async (site) => {
+      const fixture = loadOracle(site);
+      const oracle = fixture.raw.checks.commerce.x402;
+      const isCommerce = Boolean(fixture.raw.isCommerce);
+      const { fetchImpl } = makeFetchStub({
+        [`${fixture.origin}/`]: {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+          body: "",
+        },
+        [BAZAAR_URL]: {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: nonMatchingBazaar(),
+        },
+        [`${fixture.origin}/api`]: { status: 404 },
+        [`${fixture.origin}/api/v1`]: { status: 404 },
+      });
+      const ctx = createScanContext({ url: fixture.origin, fetchImpl });
+      const result = await checkX402(ctx, { isCommerce });
+      expect(result.status).toBe(oracle.status);
+      expect(result.message).toBe(oracle.message);
+    },
+  );
 });
 
 describe("x402 — non-commerce gating", () => {
@@ -290,7 +417,10 @@ describe("x402 — non-commerce gating", () => {
     );
     // Evidence length stays the same; inner conclude summary is unchanged.
     expect(result.evidence).toHaveLength(5);
-    const conclude = result.evidence[result.evidence.length - 1]!;
-    expect(conclude.finding.summary).toBe("x402 payment protocol not detected");
+    const conclude = result.evidence[result.evidence.length - 1];
+    expect(conclude).toBeDefined();
+    expect(conclude?.finding.summary).toBe(
+      "x402 payment protocol not detected",
+    );
   });
 });

--- a/tests/engine/x402.spec.ts
+++ b/tests/engine/x402.spec.ts
@@ -114,6 +114,151 @@ describe("x402 — shopify oracle (isCommerce=true)", () => {
   });
 });
 
+describe("x402 — additional coverage", () => {
+  it("passes when the homepage returns 402", async () => {
+    const origin = "https://home402.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 402,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ x402Version: 1 }),
+      },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes when /api/v1 returns 402", async () => {
+    const origin = "https://v1.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: {
+        status: 402,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ x402Version: 1 }),
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("records a bazaar failure summary when the bazaar transport errors", async () => {
+    const origin = "https://baz-err.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: new Error("ETIMEDOUT"),
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+    const bazaarStep = result.evidence[1]!;
+    expect(bazaarStep.finding.summary).toMatch(/Bazaar API request failed/);
+  });
+
+  it("records a non-200 bazaar summary when the bazaar returns 500", async () => {
+    const origin = "https://baz-500.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: { status: 500, headers: { "content-type": "text/plain" } },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+    const bazaarStep = result.evidence[1]!;
+    expect(bazaarStep.finding.summary).toBe("Bazaar API returned 500");
+  });
+
+  it("tolerates a bazaar body that is not valid JSON", async () => {
+    const origin = "https://baz-badjson.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
+
+  it("counts a top-level bazaar array payload", async () => {
+    const origin = "https://arr.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([{ origin: "https://arr.test", resource: "/api" }]),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("counts a `resources`-keyed bazaar payload", async () => {
+    const origin = "https://res.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          resources: [{ host: "res.test", resource: "/api" }],
+        }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("records a transport-error finding when a homepage probe errors", async () => {
+    const origin = "https://home-err.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: new Error("ECONNRESET"),
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+    expect(result.evidence[0]!.finding.summary).toMatch(/request failed/);
+  });
+});
+
 describe("x402 — non-commerce gating", () => {
   it("returns neutral with suffix on a non-commerce site", async () => {
     const origin = "https://vercel.com";

--- a/tests/engine/x402.spec.ts
+++ b/tests/engine/x402.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Failing specs for the `x402` commerce check.
+ *
+ * Reference: FINDINGS §3 + §9.
+ * Oracle: research/raw/scan-{shopify,vercel,cf-dev,cf,example}.json
+ *         → checks.commerce.x402
+ *
+ * Fetch plan (per FINDINGS §9):
+ *   1. GET /                                   (homepage)
+ *   2. GET https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500
+ *   3. GET /api
+ *   4. GET /api/v1
+ *
+ * Pass iff any of (1, 3, 4) return status 402 with x402 requirements,
+ * or the origin appears in the bazaar response.
+ *
+ * isCommerce gating: when the caller passes `isCommerce=false`, the check
+ * transforms its final status to "neutral" and appends " (not a commerce
+ * site)" to the message. The evidence timeline is preserved verbatim.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { makeFetchStub } from "./_helpers/oracle";
+import { createScanContext } from "@/lib/engine/context";
+import { CheckResultSchema } from "@/lib/schema";
+import { checkX402 } from "@/lib/engine/checks/x402";
+
+const BAZAAR_URL =
+  "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500";
+
+function nonMatchingBazaar(): string {
+  return JSON.stringify({ data: new Array(500).fill({ origin: "https://other.example" }) });
+}
+
+describe("x402 — shopify oracle (isCommerce=true)", () => {
+  it("fails with a 5-step evidence timeline when no 402 responses are seen", async () => {
+    const origin = "https://www.shopify.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: "",
+      },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: {
+        status: 404,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      },
+      [`${origin}/api/v1`]: {
+        status: 404,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+
+    const result = await checkX402(ctx, { isCommerce: true });
+
+    expect(CheckResultSchema.safeParse(result).success).toBe(true);
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("x402 payment protocol not detected");
+    expect(result.evidence).toHaveLength(5);
+    expect(result.evidence.map((s) => s.action)).toEqual([
+      "fetch",
+      "fetch",
+      "fetch",
+      "fetch",
+      "conclude",
+    ]);
+  });
+
+  it("passes when the origin responds with 402 on /api", async () => {
+    const origin = "https://pay.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, headers: { "content-type": "text/html" }, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: {
+        status: 402,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ x402Version: 1, accepts: [] }),
+      },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes when the origin appears in the bazaar discovery", async () => {
+    const origin = "https://in-bazaar.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, headers: { "content-type": "text/html" }, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          data: [{ origin: "https://in-bazaar.test", resource: "/api" }],
+        }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+});
+
+describe("x402 — non-commerce gating", () => {
+  it("returns neutral with suffix on a non-commerce site", async () => {
+    const origin = "https://vercel.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: "",
+      },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: {
+        status: 200,
+        headers: { "content-type": "text/markdown; charset=utf-8" },
+      },
+      [`${origin}/api/v1`]: {
+        status: 404,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: false });
+    expect(result.status).toBe("neutral");
+    expect(result.message).toBe(
+      "x402 payment protocol not detected (not a commerce site)",
+    );
+    // Evidence length stays the same; inner conclude summary is unchanged.
+    expect(result.evidence).toHaveLength(5);
+    const conclude = result.evidence[result.evidence.length - 1]!;
+    expect(conclude.finding.summary).toBe("x402 payment protocol not detected");
+  });
+});

--- a/tests/engine/x402.spec.ts
+++ b/tests/engine/x402.spec.ts
@@ -355,9 +355,138 @@ describe("x402 — additional coverage", () => {
     expect(homeStep).toBeDefined();
     expect(homeStep?.finding.summary).toMatch(/request failed/);
   });
+
+  // --- M1: hostname port-match parity -------------------------------------
+  it("matches a bazaar entry when both scan host and candidate share a non-default port (M1)", async () => {
+    const origin = "https://example.com:8443";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          data: [{ origin: "https://example.com:8443/api" }],
+        }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("matches a bare-host bazaar entry carrying an explicit port against a default-port scan (M1 fallback)", async () => {
+    const origin = "https://example.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data: [{ host: "example.com:8443" }] }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  // --- L3: trailing-dot FQDN normalisation --------------------------------
+  it("matches when the bazaar candidate uses a trailing-dot FQDN (L3)", async () => {
+    const origin = "https://a.com";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data: [{ origin: "https://a.com./" }] }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  it("matches when the scan host is FQDN trailing-dot and the bazaar candidate is not (L3 reverse)", async () => {
+    // createScanContext normalises the input URL; to exercise the reverse
+    // direction we rely on the fact that `URL` preserves a trailing dot in
+    // `hostname` when the authority was supplied with one. Since the
+    // scanner constructs `ctx.url` from the user-supplied URL string, a
+    // bare-host candidate without a trailing dot must still match.
+    const origin = "https://a.com.";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data: [{ host: "a.com" }] }),
+      },
+      [`${origin}/api`]: { status: 404 },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("pass");
+  });
+
+  // --- L1: empty accepts[] is no longer an x402 body ----------------------
+  it("does NOT pass on a 402 body whose only x402 marker is an empty accepts[] (L1)", async () => {
+    const origin = "https://empty-accepts.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: {
+        status: 402,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ accepts: [] }),
+      },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+    const apiStep = result.evidence[2];
+    expect(apiStep?.finding.summary).toMatch(
+      /402 but body is not an x402 payment requirements document/,
+    );
+  });
+
+  it("does NOT pass when x402Version is a non-scalar (L1 type check)", async () => {
+    const origin = "https://bad-version.test";
+    const { fetchImpl } = makeFetchStub({
+      [`${origin}/`]: { status: 200, body: "" },
+      [BAZAAR_URL]: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: nonMatchingBazaar(),
+      },
+      [`${origin}/api`]: {
+        status: 402,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ x402Version: { major: 1 }, accepts: [] }),
+      },
+      [`${origin}/api/v1`]: { status: 404 },
+    });
+    const ctx = createScanContext({ url: origin, fetchImpl });
+    const result = await checkX402(ctx, { isCommerce: true });
+    expect(result.status).toBe("fail");
+  });
 });
 
-describe("x402 — oracle round-trip (M1)", () => {
+// These tests assert that the check's gating behaviour (status + message)
+// is consistent across all oracle origins when the probe responses are
+// stubbed to the negative baseline. They do NOT replay the full evidence
+// timeline structurally — that is deferred pending real pass-case
+// fixtures, after which we'd switch to `expectCheckMatchesOracle`.
+describe("x402 — gating across origins", () => {
   it.each(ALL_SITES)(
     "matches the oracle status + message for %s",
     async (site) => {


### PR DESCRIPTION
Tracks task #5. Owned: impl-E. Files: lib/engine/commerce-signals.ts, lib/engine/checks/{x402,mpp,ucp,acp,ap2}.ts + specs. Shopify fixture is primary oracle. TDD + 3 iterations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for ACP, AP2, MPP, UCP, and x402 commerce/payment protocols
  * Implemented site commerce detection with aggregated platform heuristics and path probes
  * Integrated Coinbase bazaar discovery to aid x402 identification
  * Commerce gating: non-commerce sites are reported as neutral and messages are suffixed accordingly

* **Tests**
  * Added comprehensive unit tests covering detection logic, gating behavior, and evidence outputs across scenarios and origins
<!-- end of auto-generated comment: release notes by coderabbit.ai -->